### PR TITLE
Fix gp open link for .gitpod.readme.md

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,7 +16,7 @@ tasks:
       npm install
     command: |
       cd hello-world # gitpod prebuild doesnt persist the cd
-      gp open .gitpod.readme.md
+      gp open ../.gitpod.readme.md
       gp sync-await server-up
       # gp open README.md
       npm run start.watch


### PR DESCRIPTION
## What was changed
Corrects the path to `.gitpod.readme.md` as the parent of the `hello-world` directory.

## Why?
So `gp` opens the existing file, not creates a new one.

## Checklist
<!--- add/delete as needed --->

1. Closes #70

2. How was this tested: I actually don't know how to test this locally?