### PR TITLE
Add return string to logging-sinks workflow

### DIFF
--- a/logging-sinks/src/workflows.ts
+++ b/logging-sinks/src/workflows.ts
@@ -11,7 +11,8 @@ export interface LoggerSinks extends wf.Sinks {
 
 const { logger } = wf.proxySinks<LoggerSinks>();
 
-export async function logSampleWorkflow(): Promise<void> {
+export async function logSampleWorkflow(): Promise<string> {
   logger.info('Workflow execution started');
+  return 'Hello, Temporal!';
 }
 // @@@SNIPEND


### PR DESCRIPTION
## What was changed
Adds a returned string to the workflow.

## Why?
`execute-workflow.ts`  still has the `console.log(result); // Hello, Temporal!` line.

## Checklist

2. How was this tested:
Running in GitPod.

