### PR TITLE
Downgrade ESLint errors in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "eslint.rules.customizations": [
+    { "rule": "*", "severity": "downgrade" }
+  ]
+}


### PR DESCRIPTION
Handy little VS Code setting that helps disambiguate ESLint complaints from real syntax or type checking issues.
