### PR TITLE
Add build step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           # (Test command is: act --platform ubuntu-latest=lucasalt/act_base:latest)
           cache: 'npm'
       - run: npm ci
-      - run: npm run bootstrap
+      - run: npx lerna bootstrap --no-ci --npm-client=yarn
       - run: npm run build
       - run: npx prettier . --check
       - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           # Comment out cache line when testing with act:
-          # (`act --platform ubuntu-latest=lucasalt/act_base:latest`)
+          # (Test command is: act --platform ubuntu-latest=lucasalt/act_base:latest)
           cache: 'npm'
       - run: npm ci
+      - run: npm run bootstrap
+      - run: npm run build
       - run: npx prettier . --check
       - run: npm run lint
       - name: Get Temporal docker-compose.yml

--- a/.shared/tsconfig.json
+++ b/.shared/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/activities-cancellation-heartbeating/package.json
+++ b/activities-cancellation-heartbeating/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/activities-cancellation-heartbeating/tsconfig.json
+++ b/activities-cancellation-heartbeating/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/activities-dependency-injection/package.json
+++ b/activities-dependency-injection/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/activities-dependency-injection/tsconfig.json
+++ b/activities-dependency-injection/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/activities-examples/package.json
+++ b/activities-examples/package.json
@@ -5,12 +5,12 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
     "test": "ts-mocha src/test/*.test.ts",
     "test.watch": "ts-mocha src/test/*.test.ts -w --watch-files src",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/activities-examples/tsconfig.json
+++ b/activities-examples/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/activities-sticky-queues/package.json
+++ b/activities-sticky-queues/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/activities-sticky-queues/tsconfig.json
+++ b/activities-sticky-queues/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/child-workflows/package.json
+++ b/child-workflows/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/child-workflows/tsconfig.json
+++ b/child-workflows/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/continue-as-new/package.json
+++ b/continue-as-new/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/continue-as-new/tsconfig.json
+++ b/continue-as-new/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/cron-workflows/package.json
+++ b/cron-workflows/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/cron-workflows/tsconfig.json
+++ b/cron-workflows/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/dsl-interpreter/package.json
+++ b/dsl-interpreter/package.json
@@ -5,11 +5,11 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
     "workflow1": "ts-node src/client.ts ./workflow1.yaml",
-    "workflow2": "ts-node src/client.ts ./workflow2.yaml",
-    "lint": "eslint ."
+    "workflow2": "ts-node src/client.ts ./workflow2.yaml"
   },
   "nodemonConfig": {
     "execMap": {

--- a/dsl-interpreter/tsconfig.json
+++ b/dsl-interpreter/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/expense/package.json
+++ b/expense/package.json
@@ -5,13 +5,13 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "server": "ts-node src/server",
     "server.watch": "nodemon src/server/index",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
     "workflow-approve": "ts-node src/clients/approve",
-    "workflow-timeout": "ts-node src/clients/timeout",
-    "lint": "eslint ."
+    "workflow-timeout": "ts-node src/clients/timeout"
   },
   "nodemonConfig": {
     "execMap": {

--- a/expense/tsconfig.json
+++ b/expense/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/fetch-esm/package.json
+++ b/fetch-esm/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "node --loader ts-node/esm src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "node --loader ts-node/esm src/client.ts",
-    "lint": "eslint ."
+    "workflow": "node --loader ts-node/esm src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/hello-world-js/package.json
+++ b/hello-world-js/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "lint": "eslint .",
     "start": "node src/worker.js",
     "start.watch": "nodemon src/worker.js",
-    "workflow": "node src/client.js",
-    "lint": "eslint ."
+    "workflow": "node src/client.js"
   },
   "nodemonConfig": {
     "watch": [

--- a/hello-world-mtls/package.json
+++ b/hello-world-mtls/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/hello-world-mtls/tsconfig.json
+++ b/hello-world-mtls/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/hello-world/tsconfig.json
+++ b/hello-world/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/instrumentation/package.json
+++ b/instrumentation/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/instrumentation/tsconfig.json
+++ b/instrumentation/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/interceptors-opentelemetry/package.json
+++ b/interceptors-opentelemetry/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {
@@ -22,8 +22,8 @@
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/resources": "^1.0.0",
-    "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@opentelemetry/sdk-node": "^0.26.0",
+    "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@temporalio/interceptors-opentelemetry": "0.17.x",
     "temporalio": "0.17.x"
   },

--- a/interceptors-opentelemetry/tsconfig.json
+++ b/interceptors-opentelemetry/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/logging-sinks/package.json
+++ b/logging-sinks/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/logging-sinks/tsconfig.json
+++ b/logging-sinks/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/monorepo-folders/package.json
+++ b/monorepo-folders/package.json
@@ -15,6 +15,9 @@
   "dependencies": {
     "concurrently": "^6.3.0"
   },
+  "resolutions": {
+    "mini-css-extract-plugin": "2.4.5"
+  },
   "devDependencies": {
     "eslint": "^7.32.0",
     "ts-loader": "^9.2.6"

--- a/monorepo-folders/package.json
+++ b/monorepo-folders/package.json
@@ -8,12 +8,12 @@
     "frontend": "yarn workspace frontend-ui start",
     "backend": "yarn workspace backend-apis start",
     "worker": "yarn workspace temporal-worker start",
-    "build.workflows": "yarn workspace temporal-workflows compile",
+    "build": "yarn workspaces run build",
+    "build.workflows": "yarn workspace temporal-workflows build.watch",
     "start": "yarn build.workflows & concurrently --kill-others-on-fail -n 'frontend,api-server,worker' \"yarn frontend\"  \"yarn backend\" \"yarn worker\""
   },
   "dependencies": {
-    "concurrently": "^6.3.0",
-    "temporalio": "0.17.x"
+    "concurrently": "^6.3.0"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/monorepo-folders/package.json
+++ b/monorepo-folders/package.json
@@ -1,16 +1,16 @@
 {
-  "private": true,
   "name": "monorepo-folders",
+  "private": true,
   "workspaces": [
     "packages/*"
   ],
   "scripts": {
-    "frontend": "yarn workspace frontend-ui start",
     "backend": "yarn workspace backend-apis start",
-    "worker": "yarn workspace temporal-worker start",
     "build": "yarn workspaces run build",
     "build.workflows": "yarn workspace temporal-workflows build.watch",
-    "start": "yarn build.workflows & concurrently --kill-others-on-fail -n 'frontend,api-server,worker' \"yarn frontend\"  \"yarn backend\" \"yarn worker\""
+    "frontend": "yarn workspace frontend-ui start",
+    "start": "yarn build.workflows & concurrently --kill-others-on-fail -n 'frontend,api-server,worker' \"yarn frontend\"  \"yarn backend\" \"yarn worker\"",
+    "worker": "yarn workspace temporal-worker start"
   },
   "dependencies": {
     "concurrently": "^6.3.0"

--- a/monorepo-folders/packages/backend-apis/package.json
+++ b/monorepo-folders/packages/backend-apis/package.json
@@ -3,11 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "build": "tsc --build",
     "start": "nodemon server.ts --watch . --watch ../temporal-workflows"
   },
   "dependencies": {
     "express": "~4.16.1",
     "temporal-workflows": "*",
+    "temporalio": "0.17.x",
     "ts-node": "^10.4.0"
   },
   "devDependencies": {

--- a/monorepo-folders/packages/backend-apis/tsconfig.json
+++ b/monorepo-folders/packages/backend-apis/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "@tsconfig/node16/tsconfig.json",
   "version": "4.4.2",
   "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["**/*.ts"]
 }

--- a/monorepo-folders/packages/frontend-ui/package.json
+++ b/monorepo-folders/packages/frontend-ui/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "echo 'skipping frontend-ui build until issue # is solved'",
-    "build.cra": "react-scripts build",
+    "build": "react-scripts build",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
     "test": "react-scripts test"

--- a/monorepo-folders/packages/frontend-ui/package.json
+++ b/monorepo-folders/packages/frontend-ui/package.json
@@ -2,27 +2,12 @@
   "name": "frontend-ui",
   "version": "0.1.0",
   "private": true,
-  "dependencies": {
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
-    "web-vitals": "^1.0.1"
-  },
-  "proxy": "http://localhost:4000",
   "scripts": {
+    "build": "echo 'skipping frontend-ui build until issue # is solved'",
+    "build.cra": "react-scripts build",
+    "eject": "react-scripts eject",
     "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
+    "test": "react-scripts test"
   },
   "browserslist": {
     "production": [
@@ -35,5 +20,21 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "dependencies": {
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.1.0",
+    "@testing-library/user-event": "^12.1.10",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-scripts": "^5.0.0",
+    "web-vitals": "^1.0.1"
+  },
+  "proxy": "http://localhost:4000"
 }

--- a/monorepo-folders/packages/frontend-ui/package.json
+++ b/monorepo-folders/packages/frontend-ui/package.json
@@ -28,9 +28,16 @@
     ]
   },
   "dependencies": {
+    "@babel/core": "^7",
+    "@babel/plugin-syntax-flow": "^7.14.5",
+    "@babel/plugin-transform-react-jsx": "^7.14.9",
+    "@testing-library/dom": "^8.11.2",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "autoprefixer": "^10.0.2",
+    "eslint-config-react-app": "^7.0.0",
+    "postcss": "^8.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",

--- a/monorepo-folders/packages/temporal-worker/package.json
+++ b/monorepo-folders/packages/temporal-worker/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "build": "tsc --build",
     "start": "nodemon worker.ts --watch ./worker.ts --watch ../temporal-workflows"
   },
   "dependencies": {

--- a/monorepo-folders/packages/temporal-worker/tsconfig.json
+++ b/monorepo-folders/packages/temporal-worker/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "@tsconfig/node16/tsconfig.json",
   "version": "4.4.2",
   "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["**/*.ts"]
 }

--- a/monorepo-folders/packages/temporal-workflows/package.json
+++ b/monorepo-folders/packages/temporal-workflows/package.json
@@ -3,8 +3,12 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "compile": "tsc --build -w --preserveWatchOutput",
+    "build": "tsc --build",
+    "build.watch": "tsc --build -w --preserveWatchOutput",
     "lint": "eslint ."
+  },
+  "dependencies": {
+    "temporalio": "0.17.x"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.0",

--- a/monorepo-folders/packages/temporal-workflows/tsconfig.json
+++ b/monorepo-folders/packages/temporal-workflows/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/nextjs-ecommerce-oneclick/package.json
+++ b/nextjs-ecommerce-oneclick/package.json
@@ -5,6 +5,7 @@
     "dev": "npm-run-all -l build:temporal --parallel dev:temporal dev:next start:worker",
     "dev:next": "next dev",
     "dev:temporal": "tsc --build --watch ./temporal/tsconfig.json",
+    "build": "npm-run-all -l --parallel build:next build:temporal",
     "build:next": "next build",
     "build:temporal": "tsc --build ./temporal/tsconfig.json",
     "start": "npm run dev",

--- a/nextjs-ecommerce-oneclick/temporal/tsconfig.json
+++ b/nextjs-ecommerce-oneclick/temporal/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/nextjs-ecommerce-oneclick/tsconfig.json
+++ b/nextjs-ecommerce-oneclick/tsconfig.json
@@ -16,5 +16,5 @@
     "incremental": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "temporal"]
+  "exclude": ["temporal"]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "samples-typescript",
   "private": true,
   "scripts": {
-    "bootstrap": "lerna bootstrap --no-ci",
+    "bootstrap": "lerna bootstrap --npm-client=yarn",
     "build": "lerna run build",
     "test": "lerna run test",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "samples-typescript",
   "private": true,
   "scripts": {
-    "bootstrap": "lerna bootstrap",
+    "bootstrap": "lerna bootstrap --no-ci",
+    "build": "lerna run build",
     "test": "lerna run test",
     "format": "prettier --write .",
     "copy-shared-files": "zx .scripts/copy-shared-files.mjs",

--- a/patching-api/package.json
+++ b/patching-api/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/patching-api/tsconfig.json
+++ b/patching-api/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/production/package.json
+++ b/production/package.json
@@ -6,10 +6,10 @@
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
     "build:workflow": "ts-node src/scripts/build-workflow-bundle.ts",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/production/tsconfig.json
+++ b/production/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", ".eslintrc.js"]
+  "include": ["src/**/*.ts"]
 }

--- a/query-subscriptions/package.json
+++ b/query-subscriptions/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "subscribe": "ts-node src/subscribe.ts",
-    "lint": "eslint ."
+    "subscribe": "ts-node src/subscribe.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/query-subscriptions/tsconfig.json
+++ b/query-subscriptions/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/search-attributes/package.json
+++ b/search-attributes/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/search-attributes/tsconfig.json
+++ b/search-attributes/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/signals-queries/package.json
+++ b/signals-queries/package.json
@@ -5,13 +5,13 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
     "workflow.cancel": "ts-node src/cancel-workflow.ts",
-    "workflow.signal": "ts-node src/signal-workflow.ts",
-    "workflow.start": "ts-node src/start-workflow.ts",
     "workflow.query": "ts-node src/query-workflow.ts",
-    "lint": "eslint ."
+    "workflow.signal": "ts-node src/signal-workflow.ts",
+    "workflow.start": "ts-node src/start-workflow.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/signals-queries/tsconfig.json
+++ b/signals-queries/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/timer-examples/package.json
+++ b/timer-examples/package.json
@@ -5,12 +5,12 @@
   "scripts": {
     "build": "tsc --build ./tsconfig.json",
     "build.once": "tsc --build --watch ./tsconfig.json",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
     "workflow-fast": "ts-node src/clients/fast.ts",
     "workflow-slow": "ts-node src/clients/slow.ts",
-    "workflow-updating": "ts-node src/clients/updating-timer.ts",
-    "lint": "eslint ."
+    "workflow-updating": "ts-node src/clients/updating-timer.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/timer-examples/tsconfig.json
+++ b/timer-examples/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/timer-progress/package.json
+++ b/timer-progress/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
+    "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts",
-    "lint": "eslint ."
+    "workflow": "ts-node src/client.ts"
   },
   "nodemonConfig": {
     "execMap": {

--- a/timer-progress/tsconfig.json
+++ b/timer-progress/tsconfig.json
@@ -8,6 +8,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
- chore: Remove `node_modules` from shared tsconfig
`node_modules` is excluded by default: https://github.com/microsoft/TypeScript-Website/pull/2225
- Add build step to CI
So we catch more breakages
- Run `sort-package-json`
- Fix CRA@5 build and install peer deps
<details>
<summary>
Upgraded CRA because CRA build was failing in CI due to different webpack version in `../temporal-worker`
</summary>

```
| > frontend-ui
| yarn run v1.22.5
| $ react-scripts build
| info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
| info Visit https://yarnpkg.com/en/docs/cli/workspaces for documentation about this command.
| lerna ERR! npm run build stderr:
| 
| There might be a problem with the project dependency tree.
| It is likely not a bug in Create React App, but something you need to fix locally.
| 
| The react-scripts package provided by Create React App requires a dependency:
| 
|   "webpack": "4.44.2"
| 
| Don't try to install it manually: your package manager does it automatically.
| However, a different version of webpack was detected higher up in the tree:
| 
|   /Users/me/gh/samples-typescript/monorepo-folders/node_modules/webpack (version: 5.66.0) 
| 
| Manually installing incompatible versions is known to cause hard-to-debug issues.
| 
| If you would prefer to ignore this check, add SKIP_PREFLIGHT_CHECK=true to an .env file in your project.
| That will permanently disable this message but you might encounter other issues.
| 
| To fix the dependency tree, try following the steps below in the exact order:
| 
|   1. Delete package-lock.json (not package.json!) and/or yarn.lock in your project folder.
|   2. Delete node_modules in your project folder.
|   3. Remove "webpack" from dependencies and/or devDependencies in the package.json file in your project folder.
|   4. Run npm install or yarn, depending on the package manager you use.
| 
| In most cases, this should be enough to fix the problem.
| If this has not helped, there are a few other things you can try:
| 
|   5. If you used npm, install yarn (http://yarnpkg.com/) and repeat the above steps with it instead.
|      This may help because npm has known issues with package hoisting which may get resolved in future versions.
| 
|   6. Check if /Users/me/gh/samples-typescript/monorepo-folders/node_modules/webpack is outside your project directory.
|      For example, you might have accidentally installed something in your home folder.
| 
|   7. Try running npm ls webpack in your project folder.
|      This will tell you which other package (apart from the expected react-scripts) installed webpack.
| 
| If nothing else helps, add SKIP_PREFLIGHT_CHECK=true to an .env file in your project.
| That would permanently disable this preflight check in case you want to proceed anyway.
| 
| P.S. We know this message is long but please read the steps above :-) We hope you find them helpful!
| 
| error Command failed with exit code 1.
| error Command failed.
| Exit code: 1
| Command: /opt/hostedtoolcache/node/16.13.2/x64/bin/node
| Arguments: /usr/share/yarn/lib/cli.js run build
| Directory: /Users/me/gh/samples-typescript/monorepo-folders/packages/frontend-ui
| Output:
| 
| lerna ERR! npm run build exited 1 in 'monorepo-folders'
| lerna WARN complete Waiting for 4 child processes to exit. CTRL-C to exit immediately.
[CI/build-lint-test-1]   ❌  Failure - npm run build
Error: exit with `FAILURE`: 1
```

(I also tried `SKIP_PREFLIGHT_CHECK=true` in `.env` but no change)
</details>

- Get monorepo build working in CI
