### PR TITLE
Fix word spacing on nextjs-ecommerce example barebones page

### DIFF
--- a/nextjs-ecommerce-oneclick/pages/barebones.js
+++ b/nextjs-ecommerce-oneclick/pages/barebones.js
@@ -88,7 +88,7 @@ export default function Bones() {
               <a className="text-blue-400" href="https://github.com/temporalio/samples-typescript">
                 TypeScript SDK samples
               </a>{' '}
-              or
+              or{' '}
               <a className="text-blue-400" href="https://temporal.io/typescript">
                 browse our docs
               </a>


### PR DESCRIPTION
## What was changed
Tiny nit pick - when checking out the ecommerce bare bones page on a GitPod, I noticed the words were improperly spaced.

## Why?
To tidy up the page

## Checklist
1. Closes:
None

2. How was this tested:
In my GitPod - 'one click example' and edited in the code editor there.

3. Any docs updates needed?
Nope!
