### PR TITLE
use nanoid for workflow ids

### DIFF
--- a/grpc-calls/package.json
+++ b/grpc-calls/package.json
@@ -20,6 +20,7 @@
     ]
   },
   "dependencies": {
+    "nanoid": "3.x",
     "temporalio": "0.20.x"
   },
   "devDependencies": {

--- a/grpc-calls/src/client.ts
+++ b/grpc-calls/src/client.ts
@@ -1,9 +1,10 @@
 import { Connection } from '@temporalio/client';
 import { defaultPayloadConverter, toPayloads } from '@temporalio/common';
+import { nanoid } from 'nanoid';
 
 async function run() {
-  const workflowId = 'wf-id-' + Math.floor(Math.random() * 1000);
-  const requestId = 'request-id-' + Math.floor(Math.random() * 1000);
+  const workflowId = 'workflow-' + nanoid();
+  const requestId = 'request-' + nanoid();
   // @@@SNIPSTART typescript-grpc-call-basic
   const connection = new Connection();
 

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -20,6 +20,7 @@
     ]
   },
   "dependencies": {
+    "nanoid": "3.x",
     "temporalio": "0.20.x"
   },
   "devDependencies": {

--- a/hello-world/src/client.ts
+++ b/hello-world/src/client.ts
@@ -1,6 +1,7 @@
 // @@@SNIPSTART typescript-hello-client
 import { Connection, WorkflowClient } from '@temporalio/client';
 import { example } from './workflows';
+import { nanoid } from 'nanoid';
 
 async function run() {
   const connection = new Connection({
@@ -18,7 +19,7 @@ async function run() {
     args: ['Temporal'], // type inference works! args: [name: string]
     taskQueue: 'hello-world',
     // in practice, use a meaningful business id, eg customerId or transactionId
-    workflowId: 'wf-id-' + Math.floor(Math.random() * 1000),
+    workflowId: 'workflow-' + nanoid(),
   });
   console.log(`Started workflow ${handle.workflowId}`);
 


### PR DESCRIPTION
Fix #110

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Replaced `Math.random()` with [nanoid](https://www.npmjs.com/package/nanoid) for randomized Workflow ids.

## Why?
<!-- Tell your future self why have you made these changes -->

I prefer to use randomized workflow ids in samples because I like to be able to run a sample multiple times when figuring out what it does. If a sample has a hard-coded workflow id, that sample will throw an error if you try to run it multiple times, unless you change the id yourself.

As @joebowbeer pointed out, using `Math.random()` to generate workflow ids is bad practice. The risk of collisions is too high for a production application. And our samples shouldn't imply otherwise.

`nanoid` is a good alternative for generating concise, randomized ids. I'm thinking it is better than uuid because the resulting id is considerably shorter, and so leads to less ugly workflow ids in the Temporal UI.

However, I'm also considering using the built-in [crypto.randomUUID() function](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID). Using a built-in function would save us an extra dependency, but `randomUUID()` has longer output and is only supported in Node >= 16.7.0, which is slightly off from our currently supported Node version range.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
