### PR TITLE
Use fastestsmallesttextencoderdecoder

### DIFF
--- a/ejson/package.json
+++ b/ejson/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@tsconfig/node16": "^1.0.0",
     "@types/ejson": "^2.1.3",
+    "@types/fastestsmallesttextencoderdecoder": "^1.0.0",
     "@types/node": "^16.11.43",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.0.0",

--- a/ejson/src/ejson-payload-converter.ts
+++ b/ejson/src/ejson-payload-converter.ts
@@ -1,10 +1,14 @@
-// TODO switch to this once this is merged: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63028
-// import { decode, encode } from 'fastestsmallesttextencoderdecoder';
 // @@@SNIPSTART typescript-ejson-converter-impl
-import { EncodingType, METADATA_ENCODING_KEY, Payload, PayloadConverterWithEncoding } from '@temporalio/common';
-import { PayloadConverterError } from '@temporalio/internal-workflow-common';
+import {
+  EncodingType,
+  METADATA_ENCODING_KEY,
+  Payload,
+  PayloadConverterError,
+  PayloadConverterWithEncoding,
+} from '@temporalio/common';
 import EJSON from 'ejson';
-import { decode, encode } from '@temporalio/common/lib/encoding';
+import * as encoder from 'fastestsmallesttextencoderdecoder';
+console.log('encoder:', encoder);
 
 /**
  * Converts between values and [EJSON](https://docs.meteor.com/api/ejson.html) Payloads.
@@ -29,16 +33,16 @@ export class EjsonPayloadConverter implements PayloadConverterWithEncoding {
 
     return {
       metadata: {
-        [METADATA_ENCODING_KEY]: encode('json/plain'),
+        [METADATA_ENCODING_KEY]: encoder.encode('json/plain'),
         // Include an additional metadata field to indicate that this is an EJSON payload
-        format: encode('extended'),
+        format: encoder.encode('extended'),
       },
-      data: encode(ejson),
+      data: encoder.encode(ejson),
     };
   }
 
   public fromPayload<T>(content: Payload): T {
-    return content.data ? EJSON.parse(decode(content.data)) : content.data;
+    return content.data ? EJSON.parse(encoder.decode(content.data)) : content.data;
   }
 }
 


### PR DESCRIPTION
Any ideas on this webpack behavior? When I log from the client, I get:

<img width="530" alt="image" src="https://user-images.githubusercontent.com/251288/199552201-74ede43b-7ac0-4baf-b294-f080177d00c6.png">

but in the workflow, it's an empty object `{}`:

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/251288/199552421-915e90c1-137c-481f-af99-1c4114f2ae6e.png">

Similar message when importing default

```ts
import encoder from 'fastestsmallesttextencoderdecoder';
```

Repro:

```
git checkout encoding-types
cd ejson
npm i
npm start
npm run workflow
```