### PR TITLE
chore: fix outdated temporalio dependencies

### DIFF
--- a/monorepo-folders/packages/backend-apis/package.json
+++ b/monorepo-folders/packages/backend-apis/package.json
@@ -8,7 +8,7 @@
     "start": "nodemon server.ts --watch . --watch ../temporal-workflows"
   },
   "dependencies": {
-    "@temporalio/client": "1.0.0",
+    "@temporalio/client": "^1.5.2",
     "express": "~4.16.1",
     "temporal-workflows": "*",
     "ts-node": "^10.4.0"

--- a/monorepo-folders/packages/temporal-worker/package.json
+++ b/monorepo-folders/packages/temporal-worker/package.json
@@ -8,7 +8,7 @@
     "start": "nodemon worker.ts --watch ./worker.ts --watch ../temporal-workflows"
   },
   "dependencies": {
-    "@temporalio/worker": "1.0.0",
+    "@temporalio/worker": "^1.5.2",
     "temporal-workflows": "*",
     "ts-node": "^10.4.0"
   },

--- a/nestjs-counter/package.json
+++ b/nestjs-counter/package.json
@@ -24,13 +24,17 @@
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.4.0",
-    "temporalio": "1.1.0"
+    "@temporalio/activity": "^1.5.2",
+    "@temporalio/client": "^1.5.2",
+    "@temporalio/common": "^1.5.2",
+    "@temporalio/worker": "^1.5.2",
+    "@temporalio/workflow": "^1.5.2"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.1.3",
     "@nestjs/schematics": "^8.0.4",
     "@nestjs/testing": "^8.1.1",
-    "@temporalio/testing": "1.1.0",
+    "@temporalio/testing": "^1.5.2",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.1",


### PR DESCRIPTION
## What changed

- Update some outstanding dependencies on @temporalio/* to "^1.5.2"

## Why

Slack user reports having difficulty running some local code, based on the monorepo-folders example, due to some locked dependency.