### PR TITLE
Fix timer-examples

### DIFF
--- a/timer-examples/src/activities.ts
+++ b/timer-examples/src/activities.ts
@@ -15,8 +15,10 @@ const html = `Order processing is taking longer than expected, but don't worryâ€
 
 export const createActivities = ({ apiKey, domain, to, from }: MailgunSettings) => ({
   async processOrder(): Promise<void> {
+    // Delay completion to simulate work and show how to race an activity and a timer.
     const cx = Context.current();
-    await cx.sleep(cx.info.startToCloseTimeoutMs);
+    await cx.sleep(cx.info.startToCloseTimeoutMs / 2);
+    console.log('Order processed');
   },
 
   async sendNotificationEmail(): Promise<void> {

--- a/timer-examples/src/clients/fast.ts
+++ b/timer-examples/src/clients/fast.ts
@@ -7,10 +7,9 @@ async function run(): Promise<void> {
   // Does *not* send email to `process.env.ADMIN_EMAIL` that order processing is slow
   const result = await client.workflow.execute(processOrderWorkflow, {
     taskQueue: 'timer-examples',
-    workflowId: 'process-order-slow',
+    workflowId: 'process-order-fast',
     args: [{ orderProcessingMS: 100, sendDelayedEmailTimeoutMS: 1000 }],
   });
-
   console.log(result);
 }
 

--- a/timer-examples/src/clients/slow.ts
+++ b/timer-examples/src/clients/slow.ts
@@ -7,10 +7,9 @@ async function run(): Promise<void> {
   // Sends email to `process.env.ADMIN_EMAIL` that order processing is slow
   const result = await client.workflow.execute(processOrderWorkflow, {
     taskQueue: 'timer-examples',
-    workflowId: 'process-order-0',
+    workflowId: 'process-order-slow',
     args: [{ orderProcessingMS: 1000, sendDelayedEmailTimeoutMS: 100 }],
   });
-
   console.log(result);
 }
 


### PR DESCRIPTION
Sleep of `startToCloseTimeout` is guaranteed to timeout the activity, shortened that by half.