### PR TITLE
undo accidental re-adding of nestjs-counter from #236

### DIFF
--- a/.scripts/list-of-samples.json
+++ b/.scripts/list-of-samples.json
@@ -22,7 +22,6 @@
     "logger-shared",
     "monorepo-folders",
     "mutex",
-    "nestjs-counter",
     "nestjs-exchange-rates",
     "nextjs-ecommerce-oneclick",
     "patching-api",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

https://github.com/temporalio/samples-typescript/pull/236/files#diff-8295fcca3222ecc3e25ff00d35b8bb32e48cb9fd1dfd7e6469e510e18febe36f accidentally added back nestjs-counter to the list of samples, which was renamed in #235 

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
