### PR TITLE
fix(food-delivery): unable to run the example

### DIFF
--- a/food-delivery/apps/worker/src/worker.ts
+++ b/food-delivery/apps/worker/src/worker.ts
@@ -1,7 +1,7 @@
 import { NativeConnection, Worker } from '@temporalio/worker'
 import * as activities from 'activities'
 import { taskQueue } from 'common'
-import { namespace, getConnectionOptions } from 'common/lib/temporal-connection'
+import { namespace, getConnectionOptions } from '../../../packages/common/temporal-connection'
 
 async function run() {
   const connection = await NativeConnection.connect(getConnectionOptions())


### PR DESCRIPTION
In the `worker.ts` for the food-delivery example, an invalid path in `import` prevents applications from starting correctly

## What was changed

An `import` in `worker.ts` file for the food-delivery example

## Why?

The `import` directive referenced an invalid path

## Checklist

1. Closes [#240](https://github.com/temporalio/samples-typescript/issues/240) 

2. How was this tested: start the applications via `npm run dev`

