### PR TITLE
Fix incorrect file URL to Path conversion on Windows

### DIFF
--- a/fetch-esm/src/worker.ts
+++ b/fetch-esm/src/worker.ts
@@ -1,14 +1,14 @@
 // @@@SNIPSTART typescript-esm-worker
 import { Worker } from '@temporalio/worker';
-import { URL } from 'url';
+import { URL, fileURLToPath } from 'url';
 import path from 'path';
 import * as activities from './activities.js';
 
 // Support running both complied code and ts-node/esm loader
-const workflowsPath = new URL(`./workflows${path.extname(import.meta.url)}`, import.meta.url).pathname;
+const workflowsPathUrl = new URL(`./workflows${path.extname(import.meta.url)}`, import.meta.url);
 
 const worker = await Worker.create({
-  workflowsPath,
+  workflowsPath: fileURLToPath(workflowsPathUrl),
   activities,
   taskQueue: 'fetch-esm',
 });


### PR DESCRIPTION
## What changed

- Use `fileURLToPath(workflowsPathUrl)` instead of `workflowsPathUrl.path`


## Why

- On Windows, `workflowsPathUrl.path` would give something like `/C:/Users/Me/...`, which would then fail in Webpack