### PR TITLE
fix: modify duration from 5m to 5s

### DIFF
--- a/schedules/src/go-faster.ts
+++ b/schedules/src/go-faster.ts
@@ -7,7 +7,7 @@ async function run() {
 
   const handle = client.schedule.getHandle('sample-schedule');
   await handle.update((schedule: ScheduleUpdateOptions) => {
-    schedule.spec.intervals = [{ every: '5m' }];
+    schedule.spec.intervals = [{ every: '5s' }];
     return schedule;
   });
   // Alternatively:


### PR DESCRIPTION
## What was changed

Schedule `go-faster` should set the interval faster than the default 10s. I assume `5m` was a typo.

## Why?

At first I thought I did something wrong with the tutorial. Later on I found that `schedule.go-faster` actually set the interval from 10 seconds to 5 minutes. Hence, it looked like it stopped working.

## Checklist

1. Closes

Nothing. No issues created.

2. How was this tested:

I've tested this locally by running

1. `npm run schedule.start`
2. `npm run schedule.go-faster`

And checked that the scheduler runs every 5 seconds.

3. Any docs updates needed?

Not that I'm aware of.
