### PR TITLE
Add an explanation regarding `serverRootCACertificate` with Temporal Cloud

### DIFF
--- a/hello-world-mtls/src/client.ts
+++ b/hello-world-mtls/src/client.ts
@@ -7,6 +7,9 @@ import { example } from './workflows';
 /**
  * Schedule a Workflow connecting with mTLS, configuration is provided via environment variables.
  * Note that serverNameOverride and serverRootCACertificate are optional.
+ *
+ * If using Temporal Cloud, omit the serverRootCACertificate so that Node.js defaults to using
+ * Mozilla's publicly trusted list of CAs when verifying the server certificate.
  */
 async function run({
   address,
@@ -17,7 +20,8 @@ async function run({
   serverRootCACertificatePath,
   taskQueue,
 }: Env) {
-  // not needed if connecting to temporal cloud
+  // Note that the serverRootCACertificate is NOT needed if connecting to Temporal Cloud because
+  // the server certificate is issued by a publicly trusted CA.
   let serverRootCACertificate: Buffer | undefined = undefined;
   if (serverRootCACertificatePath) {
     serverRootCACertificate = fs.readFileSync(serverRootCACertificatePath);


### PR DESCRIPTION
## What was changed
Sample documentation improvement only: a brief explanation why the `serverRootCACertificate` should not be configured when connecting to Temporal Cloud. Not sure this is a great improvement but I think it would have helped me, and possibly others in future, find the configuration problem rapidly.

## Why?
It is easy to mistakenly configure the `serverRootCACertificate` when connecting to Temporal Cloud: 
* This causes Node.js to **only** use that CA certificate when verifying the Temporal Cloud server certificate. It seems that the list of publicly trusted CAs is not used in this case. Since the Temporal Cloud server certificate is signed by a publicly trusted CA, and not the self-signed certificate created as part of the tutorial, the certificate verification fails.
* As a result of the verification failure, the client connection fails with a confusing/unrelated error message: `Failed to connect before the deadline`. 
* The actual problem is not clear without setting `GRPC_TRACE=all` and `GRPC_VERBOSITY=DEBUG` which shows the root cause error message (amongst a lot of noise): `connection closed with error unable to get local issuer certificate`. 
* What made this particularly confusing for me was that the same configuration did not cause the worker `NativeConnection` to fail when connecting to Temporal Cloud, presumably because the underlying (non-Node.js?) TLS negotiation falls back on a publicly trusted CA list.

Possible alternative solutions:
* Surface the underlying GRPC error message? That message is still not very clear what the problem is, though.
* Detect when connecting to `*.tmprl.cloud` and log an explanatory warning if the `serverRootCACertificate` is configured?
* Somehow configure Node.js to fallback on the publicly trusted list of CAs when a `serverRootCACertificate` is configured? This would seem to be most consistent with how `NativeConnection` behaves.

## Checklist
1. How was this tested:
No code changed. Documentation/comment only. Tested that it still builds.

2. Any docs updates needed?
It might be worth calling out this potential gotcha more explicitly in the [Connecting to Temporal Cloud (with mTLS)](https://legacy-documentation-sdks.temporal.io/typescript/security/#connecting-to-temporal-cloud-with-mtls) docs? I'm not sure if "current" docs have this section as I could only find it in the "legacy" docs. I had originally followed the self-hosted instructions for local development/testing before switching to Temporal Cloud for deployment which is where I probably missed the note that the configuration is "not usually needed".