### PR TITLE
doc(activities-cancellation-heartbeating): fix doc links

### DIFF
--- a/activities-cancellation-heartbeating/README.md
+++ b/activities-cancellation-heartbeating/README.md
@@ -5,7 +5,7 @@ This sample demonstrates:
 - How a retried Activity Task can resume from the last Activity Task's heartbeat.
 - How to handle canceling a long-running Activity when its associated Workflow is canceled.
 
-Docs: [Activity heartbeating](https://docs.temporal.io/application-development/features?lang=typescript/#activity-heartbeats) and [cancellation](https://docs.temporal.io/application-development/testing/#cancel-an-activity)
+Docs: [Activity heartbeating](https://docs.temporal.io/dev-guide/typescript/features#activity-heartbeats) and [cancellation](https://typescript.temporal.io/api/namespaces/activity#cancellation)
 
 Running [`src/client.ts`](./src/client.ts) does this:
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
I updated some documentation links for the `activities-cancellation-heartbeating` sample.

## Why?
The links were broken.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
