### PR TITLE
Add tests to hello world example

### DIFF
--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -22,14 +22,14 @@
     ]
   },
   "dependencies": {
-    "@temporalio/activity": "1.8.5",
-    "@temporalio/client": "1.8.5",
-    "@temporalio/worker": "1.8.5",
-    "@temporalio/workflow": "1.8.5",
+    "@temporalio/activity": "^1.8.4",
+    "@temporalio/client": "^1.8.4",
+    "@temporalio/worker": "^1.8.4",
+    "@temporalio/workflow": "^1.8.4",
     "nanoid": "3.x"
   },
   "devDependencies": {
-    "@temporalio/testing": "1.8.5",
+    "@temporalio/testing": "^1.8.4",
     "@tsconfig/node16": "^1.0.0",
     "@types/mocha": "8.x",
     "@types/node": "^16.11.43",

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -8,7 +8,9 @@
     "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts"
+    "workflow": "ts-node src/client.ts",
+    "format": "prettier --config .prettierrc 'src/**/*.ts' --write",
+    "test": "mocha --exit --require ts-node/register --require source-map-support/register src/mocha/*.test.ts"
   },
   "nodemonConfig": {
     "execMap": {
@@ -20,22 +22,23 @@
     ]
   },
   "dependencies": {
-    "@temporalio/activity": "^1.8.4",
-    "@temporalio/client": "^1.8.4",
-    "@temporalio/worker": "^1.8.4",
-    "@temporalio/workflow": "^1.8.4",
-    "@types/node-fetch": "^2.6.4",
-    "nanoid": "3.x",
-    "node-fetch": "^2.6.2"
+    "@temporalio/activity": "1.8.5",
+    "@temporalio/client": "1.8.5",
+    "@temporalio/worker": "1.8.5",
+    "@temporalio/workflow": "1.8.5",
+    "nanoid": "3.x"
   },
   "devDependencies": {
+    "@temporalio/testing": "1.8.5",
     "@tsconfig/node16": "^1.0.0",
+    "@types/mocha": "8.x",
     "@types/node": "^16.11.43",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-deprecation": "^1.2.1",
+    "mocha": "8.x",
     "nodemon": "^2.0.12",
     "prettier": "^2.8.8",
     "ts-node": "^10.8.1",

--- a/hello-world/src/mocha/activities.test.ts
+++ b/hello-world/src/mocha/activities.test.ts
@@ -1,0 +1,13 @@
+import { MockActivityEnvironment } from '@temporalio/testing';
+import { describe, it } from 'mocha';
+import * as activities from '../activities';
+import assert from 'assert';
+
+describe('greet activity', async () => {
+  it('successfully greets the user', async () => {
+    const env = new MockActivityEnvironment();
+    const name = 'Temporal';
+    const result = await env.run(activities.greet, name);
+    assert.equal(result, 'Hello, Temporal!');
+  });
+});

--- a/hello-world/src/mocha/workflows-mocks.test.ts
+++ b/hello-world/src/mocha/workflows-mocks.test.ts
@@ -8,7 +8,7 @@ describe('Example workflow with mocks', () => {
   let testEnv: TestWorkflowEnvironment;
 
   before(async () => {
-    testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+    testEnv = await TestWorkflowEnvironment.createLocal();
   });
 
   after(async () => {

--- a/hello-world/src/mocha/workflows-mocks.test.ts
+++ b/hello-world/src/mocha/workflows-mocks.test.ts
@@ -1,0 +1,40 @@
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { after, before, it } from 'mocha';
+import { Worker } from '@temporalio/worker';
+import { example } from '../workflows';
+import assert from 'assert';
+
+describe('Example workflow with mocks', () => {
+  let testEnv: TestWorkflowEnvironment;
+
+  before(async () => {
+    testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+  });
+
+  after(async () => {
+    await testEnv?.teardown();
+  });
+
+  it('successfully completes the Workflow with a mocked Activity', async () => {
+    const { client, nativeConnection } = testEnv;
+    const taskQueue = 'test';
+
+    const worker = await Worker.create({
+      connection: nativeConnection,
+      taskQueue,
+      workflowsPath: require.resolve('../workflows'),
+      activities: {
+        greet: async () => 'Hello, Temporal!',
+      },
+    });
+
+    const result = await worker.runUntil(
+      client.workflow.execute(example, {
+        args: ['Temporal'],
+        workflowId: 'test',
+        taskQueue,
+      })
+    );
+    assert.equal(result, 'Hello, Temporal!');
+  });
+});

--- a/hello-world/src/mocha/workflows.test.ts
+++ b/hello-world/src/mocha/workflows.test.ts
@@ -9,7 +9,7 @@ describe('Example workflow', () => {
   let testEnv: TestWorkflowEnvironment;
 
   before(async () => {
-    testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+    testEnv = await TestWorkflowEnvironment.createLocal();
   });
 
   after(async () => {

--- a/hello-world/src/mocha/workflows.test.ts
+++ b/hello-world/src/mocha/workflows.test.ts
@@ -1,0 +1,39 @@
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { before, describe, it } from 'mocha';
+import { Worker } from '@temporalio/worker';
+import { example } from '../workflows';
+import * as activities from '../activities';
+import assert from 'assert';
+
+describe('Example workflow', () => {
+  let testEnv: TestWorkflowEnvironment;
+
+  before(async () => {
+    testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+  });
+
+  after(async () => {
+    await testEnv?.teardown();
+  });
+
+  it('successfully completes the Workflow', async () => {
+    const { client, nativeConnection } = testEnv;
+    const taskQueue = 'test';
+
+    const worker = await Worker.create({
+      connection: nativeConnection,
+      taskQueue,
+      workflowsPath: require.resolve('../workflows'),
+      activities,
+    });
+
+    const result = await worker.runUntil(
+      client.workflow.execute(example, {
+        args: ['Temporal'],
+        workflowId: 'test',
+        taskQueue,
+      })
+    );
+    assert.equal(result, 'Hello, Temporal!');
+  });
+});

--- a/hello-world/tsconfig.json
+++ b/hello-world/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "@tsconfig/node16/tsconfig.json",
   "version": "4.4.2",
   "compilerOptions": {
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
The Hello World example gets pulled in as the default when using the `npx @temporalio/create` script and it's a good starting point for basic Temporal demo apps.

I think it should ship with tests, so I've added three:

1. An Activity test
2. A workflow test that does run the Activity
3. A Workflow test that mocks the Activitiy.

These tests come from the 102 TypeScript curriculum.

They do not include nyc coverage as I thought that complicated things.

Open to feedback.