### PR TITLE
Fix issue #310

### DIFF
--- a/worker-specific-task-queues/src/activities.ts
+++ b/worker-specific-task-queues/src/activities.ts
@@ -13,6 +13,13 @@ export function createNormalActivities(uniqueWorkerTaskQueue: string) {
 function delay(ms: number) {
   return new Promise( resolve => setTimeout(resolve, ms) );
 }
+function tsleep(ms: number, cancelled: Promise<never>){
+  let handle: NodeJS.Timeout;
+  const timer = new Promise<void>((resolve) => {
+    handle = setTimeout(resolve, ms);
+  });
+  return Promise.race([cancelled.finally(() => clearTimeout(handle)), timer]);
+}
 export function createActivitiesForSameWorker() {
   return {
     async downloadFileToWorkerFileSystem(url: string, path: string): Promise<void> {
@@ -20,19 +27,22 @@ export function createActivitiesForSameWorker() {
       log.info('Downloading and saving', { url, path });
       // Here's where the real download code goes
       const body = Buffer.from('downloaded body');
-      await delay(3000);
+      log.info("cancellation aware sleep");
+      await tsleep(3000, Context.current().cancelled);
       await fs.writeFile(path, body);
     },
     async workOnFileInWorkerFileSystem(path: string): Promise<void> {
       const { log } = Context.current();
       const content = await fs.readFile(path);
       const checksum = createHash('md5').update(content).digest('hex');
-      await delay(3000);
+      log.info("cancellation aware sleep");
+      await tsleep(3000, Context.current().cancelled);
       log.info('Did some work', { path, checksum });
     },
     async cleanupFileFromWorkerFileSystem(path: string): Promise<void> {
       const { log } = Context.current();
-      await delay(3000);
+      log.info("cancellation aware sleep");
+      await tsleep(3000, Context.current().cancelled);
       log.info('Cleaning up temp file', { path });
       await fs.rm(path);
     },

--- a/worker-specific-task-queues/src/activities.ts
+++ b/worker-specific-task-queues/src/activities.ts
@@ -37,8 +37,7 @@ export function createActivitiesForSameWorker() {
       const content = await fs.readFile(path);
       const checksum = createHash('md5').update(content).digest('hex');
       const context = Context.current();
-      const cancellation = Context.current().cancelled;
-      log.info("cancellation token", cancellation)
+      log.info("this context preserved")
       await context.sleep(3000);
       log.info('Did some work', { path, checksum });
     },

--- a/worker-specific-task-queues/src/activities.ts
+++ b/worker-specific-task-queues/src/activities.ts
@@ -10,6 +10,7 @@ export function createNormalActivities(uniqueWorkerTaskQueue: string) {
     },
   };
 }
+//  Workflow.sleep(...) may only be used from a Workflow Execution
 function delay(ms: number) {
   return new Promise( resolve => setTimeout(resolve, ms) );
 }
@@ -35,14 +36,16 @@ export function createActivitiesForSameWorker() {
       const { log } = Context.current();
       const content = await fs.readFile(path);
       const checksum = createHash('md5').update(content).digest('hex');
-      log.info("cancellation aware sleep");
-      await tsleep(3000, Context.current().cancelled);
+      const context = Context.current();
+      const cancellation = Context.current().cancelled;
+      log.info("cancellation token", cancellation)
+      await context.sleep(3000);
       log.info('Did some work', { path, checksum });
     },
     async cleanupFileFromWorkerFileSystem(path: string): Promise<void> {
       const { log } = Context.current();
       log.info("cancellation aware sleep");
-      await tsleep(3000, Context.current().cancelled);
+      await delay(3000);
       log.info('Cleaning up temp file', { path });
       await fs.rm(path);
     },

--- a/worker-specific-task-queues/src/activities.ts
+++ b/worker-specific-task-queues/src/activities.ts
@@ -10,27 +10,29 @@ export function createNormalActivities(uniqueWorkerTaskQueue: string) {
     },
   };
 }
-
+function delay(ms: number) {
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}
 export function createActivitiesForSameWorker() {
   return {
     async downloadFileToWorkerFileSystem(url: string, path: string): Promise<void> {
-      const { log, sleep } = Context.current();
+      const { log } = Context.current();
       log.info('Downloading and saving', { url, path });
       // Here's where the real download code goes
       const body = Buffer.from('downloaded body');
-      await sleep(3000);
+      await delay(3000);
       await fs.writeFile(path, body);
     },
     async workOnFileInWorkerFileSystem(path: string): Promise<void> {
-      const { log, sleep } = Context.current();
+      const { log } = Context.current();
       const content = await fs.readFile(path);
       const checksum = createHash('md5').update(content).digest('hex');
-      await sleep(3000);
+      await delay(3000);
       log.info('Did some work', { path, checksum });
     },
     async cleanupFileFromWorkerFileSystem(path: string): Promise<void> {
-      const { log, sleep } = Context.current();
-      await sleep(3000);
+      const { log } = Context.current();
+      await delay(3000);
       log.info('Cleaning up temp file', { path });
       await fs.rm(path);
     },


### PR DESCRIPTION

## What was changed
Using delay instead of sleep in Worker-Specific Task Queues

## Why?
See the related issue https://github.com/temporalio/samples-typescript/issues/310

## Checklist
Verify why importing sleep from current context is wrong.

1. Closes 310

2. How was this tested:
Running in Gitpod (it's already a one click configuration, nothing special to do)

3. Any docs updates needed?
It's only a one liner fix, no docs to be updated, really.
