### PR TITLE
Fixed fakeProgress activity heartbeat

### DIFF
--- a/activities-cancellation-heartbeating/src/activities.ts
+++ b/activities-cancellation-heartbeating/src/activities.ts
@@ -7,11 +7,12 @@ export async function fakeProgress(sleepIntervalMs = 1000): Promise<void> {
     const startingPoint = activityInfo().heartbeatDetails || 1;
     log.info('Starting activity at progress', { startingPoint });
     for (let progress = startingPoint; progress <= 100; ++progress) {
+      // heartbeat immediately after entering loop to retry activity from last failed progress
+      heartbeat(progress);
       // simple utility to sleep in activity for given interval or throw if Activity is cancelled
       // don't confuse with Workflow.sleep which is only used in Workflow functions!
       log.info('Progress', { progress });
       await sleep(sleepIntervalMs);
-      heartbeat(progress);
     }
   } catch (err) {
     if (err instanceof CancelledFailure) {


### PR DESCRIPTION
## What was changed
Changed activity(long-running activity) to heartbeat immediately 

## Why?
If the activity heartbeats after operation such as DB insertion or reads, when failed the activity retries from a progress point which is success, which results in inconsistency. 

1. Closes - https://github.com/temporalio/samples-typescript/issues/366

2. How was this tested:
I have tested this in my personal project, one can test and replicate this by data insertion in the fakeProgress activity instead of `await sleep(...)` code line.

3. Any docs updates needed?
Yes, code sample in the documentation should be updated and this should be described for better understanding.
https://docs.temporal.io/dev-guide/typescript/features#activity-heartbeats
