### PR TITLE
Next.js Oneclick: Reuse Temporal Connection across API invocations

### DIFF
--- a/nextjs-ecommerce-oneclick/pages/api/cancelBuy.js
+++ b/nextjs-ecommerce-oneclick/pages/api/cancelBuy.js
@@ -1,4 +1,4 @@
-import { Client } from '@temporalio/client';
+import { getTemporalClient } from '../../temporal/lib/client.js';
 
 export default async function cancelBuy(req, res) {
   const { id } = req.query;
@@ -7,8 +7,7 @@ export default async function cancelBuy(req, res) {
     return;
   }
 
-  const client = new Client();
-  const workflow = client.workflow.getHandle(id);
+  const workflow = await getTemporalClient().workflow.getHandle(id);
   try {
     await workflow.signal('cancelPurchase');
     res.status(200).json({ cancelled: id });

--- a/nextjs-ecommerce-oneclick/pages/api/getBuyState.js
+++ b/nextjs-ecommerce-oneclick/pages/api/getBuyState.js
@@ -1,4 +1,4 @@
-import { Client } from '@temporalio/client';
+import { getTemporalClient } from '../../temporal/lib/client.js';
 
 export default async function queryState(req, res) {
   const { id } = req.query;
@@ -7,9 +7,8 @@ export default async function queryState(req, res) {
     return;
   }
 
-  const client = new Workflow();
   console.log({ id });
-  const workflow = client.workflow.getHandle(id);
+  const workflow = await getTemporalClient().workflow.getHandle(id);
   try {
     const purchaseState = await workflow.query('purchaseState');
     res.status(200).json({ purchaseState });

--- a/nextjs-ecommerce-oneclick/pages/api/startBuy.js
+++ b/nextjs-ecommerce-oneclick/pages/api/startBuy.js
@@ -1,5 +1,5 @@
-import { Connection, Client } from '@temporalio/client';
 import { OneClickBuy } from '../../temporal/lib/workflows.js';
+import { getTemporalClient } from '../../temporal/lib/client.js';
 
 export default async function startBuy(req, res) {
   if (req.method !== 'POST') {
@@ -12,14 +12,8 @@ export default async function startBuy(req, res) {
     res.status(405).send({ message: 'must send itemId to buy' });
     return;
   }
-  // Connect to localhost with default ConnectionOptions,
-  // pass options to the Connection constructor to configure TLS and other settings.
-  const connection = await Connection.connect();
-  // Workflows will be started in the "default" namespace unless specified otherwise
-  // via options passed the Client constructor.
-  const client = new Client({ connection });
   // kick off the purchase async
-  await client.workflow.start(OneClickBuy, {
+  await getTemporalClient().workflow.start(OneClickBuy, {
     taskQueue: 'ecommerce-oneclick',
     workflowId: transactionId,
     args: [itemId],

--- a/nextjs-ecommerce-oneclick/pages/index.tsx
+++ b/nextjs-ecommerce-oneclick/pages/index.tsx
@@ -24,7 +24,7 @@ function fetchAPI(str, obj?: RequestInit) {
         closeOnClick: true,
         draggable: true,
       });
-      // throw err
+      throw err;
     });
 }
 
@@ -147,24 +147,28 @@ function Product({ product }) {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ itemId, transactionId }),
-    }).then(() => {
-      setState('ORDERED');
-      toastId.current = toast.success('Purchased! Cancel if you change your mind', {
-        position: 'top-right',
-        autoClose: 5000,
-        closeOnClick: true,
-        draggable: true,
-        onClose: () => {
-          console.log({ state: stateRef.current });
-          if (stateRef.current === 'ORDERED') {
-            setState('CONFIRMED');
-          } else if (stateRef.current === 'CANCELLING') {
-            setState('NEW');
-            setTransactionId(uuid4());
-          }
-        },
+    })
+      .then(() => {
+        setState('ORDERED');
+        toastId.current = toast.success('Purchased! Cancel if you change your mind', {
+          position: 'top-right',
+          autoClose: 5000,
+          closeOnClick: true,
+          draggable: true,
+          onClose: () => {
+            console.log({ state: stateRef.current });
+            if (stateRef.current === 'ORDERED') {
+              setState('CONFIRMED');
+            } else if (stateRef.current === 'CANCELLING') {
+              setState('NEW');
+              setTransactionId(uuid4());
+            }
+          },
+        });
+      })
+      .catch(() => {
+        setState('ERROR');
       });
-    });
   }
   // function getState() {
   //   if (workflowId) {

--- a/nextjs-ecommerce-oneclick/temporal/src/activities.ts
+++ b/nextjs-ecommerce-oneclick/temporal/src/activities.ts
@@ -1,6 +1,7 @@
 export async function checkoutItem(itemId: string): Promise<string> {
   return `checking out ${itemId}!`;
 }
+
 export async function canceledPurchase(itemId: string): Promise<string> {
   return `canceled purchase ${itemId}!`;
 }

--- a/nextjs-ecommerce-oneclick/temporal/src/client.ts
+++ b/nextjs-ecommerce-oneclick/temporal/src/client.ts
@@ -1,0 +1,15 @@
+import { Client, Connection } from '@temporalio/client';
+
+const client: Client = makeClient();
+
+function makeClient(): Client {
+  const connection = Connection.lazy({
+    address: 'localhost:7233',
+    // In production, pass options to configure TLS and other settings.
+  });
+  return new Client({ connection });
+}
+
+export function getTemporalClient(): Client {
+  return client;
+}

--- a/nextjs-ecommerce-oneclick/temporal/src/worker.ts
+++ b/nextjs-ecommerce-oneclick/temporal/src/worker.ts
@@ -1,15 +1,22 @@
-import { Worker } from '@temporalio/worker';
+import { NativeConnection, Worker } from '@temporalio/worker';
 import * as activities from './activities';
 
 run().catch((err) => console.log(err));
 
 async function run() {
-  const worker = await Worker.create({
-    workflowsPath: require.resolve('./workflows'),
-    activities,
-    taskQueue: 'ecommerce-oneclick',
+  const connection = await NativeConnection.connect({
+    address: 'localhost:7233',
+    // In production, pass options to configure TLS and other settings.
   });
-
-  // Start accepting tasks on the `tutorial` queue
-  await worker.run();
+  try {
+    const worker = await Worker.create({
+      connection,
+      workflowsPath: require.resolve('./workflows'),
+      activities,
+      taskQueue: 'ecommerce-oneclick',
+    });
+    await worker.run();
+  } finally {
+    connection.close();
+  }
 }

--- a/nextjs-ecommerce-oneclick/temporal/src/workflows.ts
+++ b/nextjs-ecommerce-oneclick/temporal/src/workflows.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import * as wf from '@temporalio/workflow';
-// // Only import the activity types
+// Only import the activity types
 import type * as activities from './activities';
 
 const { checkoutItem, canceledPurchase } = wf.proxyActivities<typeof activities>({


### PR DESCRIPTION
## What was changed and why?

- Move Temporal Connection and Client initialization to a distinct module
  - Avoids creating a new Connection on each API calls. gRPC connections are heavyweight and show be reused as much as possible.

- Fixed the UI side request state machine
  - It was masking failed API calls, resulting in incorrect "Purchased!" messages.

## Misc
- Closes #322 