### PR TITLE
Fix cluster start/stop

### DIFF
--- a/message-passing/safe-message-handlers/src/activities.ts
+++ b/message-passing/safe-message-handlers/src/activities.ts
@@ -15,6 +15,11 @@ export async function startCluster(): Promise<void> {
   await activities.sleep(100); // Simulate RPC
 }
 
+export async function shutdownCluster(): Promise<void> {
+  activities.log.info('Shutting down cluster');
+  await activities.sleep(100); // Simulate RPC
+}
+
 export async function assignNodesToJob(input: AssignNodesToJobInput): Promise<void> {
   activities.log.info(`Assigning nodes ${input.nodes} to job ${input.jobName}`);
   await activities.sleep(100); // Simulate RPC

--- a/message-passing/safe-message-handlers/src/cluster-manager.ts
+++ b/message-passing/safe-message-handlers/src/cluster-manager.ts
@@ -40,11 +40,13 @@ export class ClusterManager {
     if (this.state.clusterState === ClusterState.UP) {
       return;
     }
-    await startCluster();
-    this.state.clusterState = ClusterState.UP;
-    for (let i = 0; i < 25; i++) {
-      this.state.nodes.set(i.toString(), null);
-    }
+    await this.nodesMutex.runExclusive(async () => {
+      await startCluster();
+      this.state.clusterState = ClusterState.UP;
+      for (let i = 0; i < 25; i++) {
+        this.state.nodes.set(i.toString(), null);
+      }
+    });
     wf.log.info('Cluster started');
   }
 

--- a/message-passing/safe-message-handlers/src/cluster-manager.ts
+++ b/message-passing/safe-message-handlers/src/cluster-manager.ts
@@ -4,11 +4,12 @@ import { Mutex } from 'async-mutex';
 import {
   AssignNodesToJobUpdateInput,
   ClusterManagerState,
+  ClusterState,
   ClusterManagerStateSummary,
   DeleteJobUpdateInput,
 } from './types';
 
-const { assignNodesToJob, unassignNodesForJob, startCluster } = wf.proxyActivities<typeof activities>({
+const { assignNodesToJob, unassignNodesForJob, startCluster, shutdownCluster } = wf.proxyActivities<typeof activities>({
   startToCloseTimeout: '1 minute',
 });
 
@@ -27,8 +28,7 @@ export class ClusterManager {
 
   constructor(state?: ClusterManagerState) {
     this.state = state ?? {
-      clusterStarted: false,
-      clusterShutdown: false,
+      clusterState: ClusterState.DOWN,
       nodes: new Map<string, string | null>(),
       maxAssignedNodes: 0,
     };
@@ -37,23 +37,30 @@ export class ClusterManager {
   }
 
   async startCluster(): Promise<void> {
+    if (this.state.clusterState === ClusterState.UP) {
+      return;
+    }
     await startCluster();
-    this.state.clusterStarted = true;
+    this.state.clusterState = ClusterState.UP;
     for (let i = 0; i < 25; i++) {
       this.state.nodes.set(i.toString(), null);
     }
     wf.log.info('Cluster started');
   }
 
-  async shutDownCluster(): Promise<void> {
-    await wf.condition(() => this.state.clusterStarted);
-    this.state.clusterShutdown = true;
+  async shutDownCluster(): Promise<true> {
+    if (this.state.clusterState === ClusterState.DOWN) {
+      throw new wf.ApplicationFailure('Cluster is already down');
+    }
+    await shutdownCluster();
+    this.state.clusterState = ClusterState.DOWN;
     wf.log.info('Cluster shutdown');
+    return true;
   }
 
   async assignNodesToJob(input: AssignNodesToJobUpdateInput): Promise<ClusterManagerStateSummary> {
-    await wf.condition(() => this.state.clusterStarted);
-    if (this.state.clusterShutdown) {
+    await wf.condition(() => this.state.clusterState === ClusterState.UP);
+    if (this.state.clusterState === ClusterState.DOWN) {
       // If you want the client to receive a failure, either add an update validator and throw the
       // exception from there, or raise an ApplicationError. Other exceptions in the handler will
       // cause the workflow to keep retrying and get it stuck.
@@ -83,8 +90,8 @@ export class ClusterManager {
   }
 
   async deleteJob(input: DeleteJobUpdateInput) {
-    await wf.condition(() => this.state.clusterStarted);
-    if (this.state.clusterShutdown) {
+    await wf.condition(() => this.state.clusterState === ClusterState.UP);
+    if (this.state.clusterState === ClusterState.DOWN) {
       // If you want the client to receive a failure, either add an update validator and throw the
       // exception from there, or raise an ApplicationError. Other exceptions in the handler will
       // cause the workflow to keep retrying and get it stuck.
@@ -105,8 +112,7 @@ export class ClusterManager {
 
   getState(): ClusterManagerState {
     return {
-      clusterStarted: this.state.clusterStarted,
-      clusterShutdown: this.state.clusterShutdown,
+      clusterState: this.state.clusterState,
       nodes: this.state.nodes,
       maxAssignedNodes: this.state.maxAssignedNodes,
     };

--- a/message-passing/safe-message-handlers/src/run-simulation.ts
+++ b/message-passing/safe-message-handlers/src/run-simulation.ts
@@ -1,6 +1,6 @@
 import { WorkflowHandle } from '@temporalio/client';
 
-import { assignNodesToJobUpdate, startClusterSignal, deleteJobUpdate, shutdownClusterSignal } from './workflows';
+import { assignNodesToJobUpdate, startClusterSignal, deleteJobUpdate, shutdownClusterUpdate } from './workflows';
 import { startClusterManager } from './client';
 import { setTimeout } from 'timers/promises';
 
@@ -23,7 +23,9 @@ async function runSimulation(wf: WorkflowHandle, delaySeconds?: number): Promise
   }
   await Promise.all(deletionUpdates);
 
-  await wf.signal(shutdownClusterSignal);
+  if (!(await wf.executeUpdate(shutdownClusterUpdate))) {
+    throw new Error('Failed to shutdown cluster');
+  }
 }
 
 async function main() {

--- a/message-passing/safe-message-handlers/src/test/workflows.test.ts
+++ b/message-passing/safe-message-handlers/src/test/workflows.test.ts
@@ -2,11 +2,12 @@ import { TestWorkflowEnvironment } from '@temporalio/testing';
 import { before, describe, it } from 'mocha';
 import { bundleWorkflowCode, WorkflowBundleWithSourceMap, DefaultLogger, Runtime, Worker } from '@temporalio/worker';
 import * as activities from '../activities';
+import * as client from '@temporalio/client';
 import {
   clusterManagerWorkflow,
   assignNodesToJobUpdate,
   startClusterSignal,
-  shutdownClusterSignal,
+  shutdownClusterUpdate,
   deleteJobUpdate,
   getClusterStatusQuery,
 } from '../workflows';
@@ -81,7 +82,7 @@ describe('cluster manager', function () {
       );
       assert.equal(queryResult.maxAssignedNodes, request1.numNodes + request2.numNodes);
       // Terminate the workflow and check that workflow returns same value as obtained from last query.
-      await workflow.signal(shutdownClusterSignal);
+      assert.equal(await workflow.executeUpdate(shutdownClusterUpdate), true);
       const wfResult = await workflow.result();
       assert.deepEqual(wfResult, queryResult);
     });

--- a/message-passing/safe-message-handlers/src/types.ts
+++ b/message-passing/safe-message-handlers/src/types.ts
@@ -1,6 +1,5 @@
 export interface ClusterManagerState {
-  clusterStarted: boolean;
-  clusterShutdown: boolean;
+  clusterState: ClusterState;
   nodes: Map<string, string | null>;
   maxAssignedNodes: number;
 }
@@ -27,4 +26,9 @@ export interface ClusterManagerWorkflowResult {
   maxAssignedNodes: number;
   numCurrentlyAssignedNodes: number;
   numBadNodes: number;
+}
+
+export enum ClusterState {
+  UP = 'UP',
+  DOWN = 'DOWN',
 }


### PR DESCRIPTION
- Use an update for `clusterStop`: fixes bug wherein `stop` sent while cluster is down would hang until it comes up, then take it down
- Make `clusterStart` idempotent: fixes bug wherein a `start` sent while the cluster was up would overwrite the nodes data
- Do `clusterStart` with lock held (otherwise an assign job could come in while it's initializing
- Use an enum for cluster state instead of boolean flags 