### PR TITLE
Update Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node: [ 16, 18, 20 ]
+        node: [ 18, 20, 22 ]
         project:
           [
             activities-examples,
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           # Comment out cache line when testing with act:
           # (Test command is: act --platform ubuntu-latest=lucasalt/act_base:latest)
           cache: 'npm'

--- a/custom-logger/src/logging.ts
+++ b/custom-logger/src/logging.ts
@@ -20,8 +20,13 @@ const devLogFormat = winston.format.printf(({ level, message, label, timestamp, 
   // The type signature in winston is wrong
   const { [LEVEL]: _lvl, [SPLAT]: _splt, [MESSAGE]: _msg, ...restNoSymbols } = rest as Record<string | symbol, any>;
   return Object.keys(restNoSymbols).length === 0
-    ? `${getDateStr(timestamp)} [${label}] ${level}: ${message}`
-    : `${getDateStr(timestamp)} [${label}] ${level}: ${message} ${util.inspect(restNoSymbols, false, 4, true)}`;
+    ? `${getDateStr(timestamp as number)} [${label}] ${level}: ${message}`
+    : `${getDateStr(timestamp as number)} [${label}] ${level}: ${message} ${util.inspect(
+        restNoSymbols,
+        false,
+        4,
+        true
+      )}`;
 });
 
 /** Create a winston logger from given options */

--- a/food-delivery/package.json
+++ b/food-delivery/package.json
@@ -22,7 +22,7 @@
     "vercel": "^29.0.3"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
- For food-delivery: Bump the required Node version to Node 22 (the current LTS), since Node 14 is deprecated.
- Update CI to use Node 22 and drop Node 16 (no longer supported).
- While I'm here, fix a compile error in the `custom-logger` example.