### PR TITLE
Close all explicitly created NativeConnection

### DIFF
--- a/empty/src/worker.ts
+++ b/empty/src/worker.ts
@@ -12,25 +12,30 @@ async function run() {
     address: 'localhost:7233',
     // TLS and gRPC metadata configuration goes here.
   });
-  // Step 2: Register Workflows and Activities with the Worker.
-  const worker = await Worker.create({
-    connection,
-    namespace: 'default',
-    taskQueue: TASK_QUEUE_NAME,
-    // Workflows are registered using a path as they run in a separate JS context.
-    workflowsPath: require.resolve('./workflows'),
-    activities,
-  });
+  try {
+    // Step 2: Register Workflows and Activities with the Worker.
+    const worker = await Worker.create({
+      connection,
+      namespace: 'default',
+      taskQueue: TASK_QUEUE_NAME,
+      // Workflows are registered using a path as they run in a separate JS context.
+      workflowsPath: require.resolve('./workflows'),
+      activities,
+    });
 
-  // Step 3: Start accepting tasks on the Task Queue specified in TASK_QUEUE_NAME
-  //
-  // The worker runs until it encounters an unexpected error or the process receives a shutdown signal registered on
-  // the SDK Runtime object.
-  //
-  // By default, worker logs are written via the Runtime logger to STDERR at INFO level.
-  //
-  // See https://typescript.temporal.io/api/classes/worker.Runtime#install to customize these defaults.
-  await worker.run();
+    // Step 3: Start accepting tasks on the Task Queue specified in TASK_QUEUE_NAME
+    //
+    // The worker runs until it encounters an unexpected error or the process receives a shutdown signal registered on
+    // the SDK Runtime object.
+    //
+    // By default, worker logs are written via the Runtime logger to STDERR at INFO level.
+    //
+    // See https://typescript.temporal.io/api/classes/worker.Runtime#install to customize these defaults.
+    await worker.run();
+  } finally {
+    // Close the connection once the worker has stopped
+    await connection.close();
+  }
 }
 
 run().catch((err) => {

--- a/food-delivery/apps/worker/src/worker.ts
+++ b/food-delivery/apps/worker/src/worker.ts
@@ -5,15 +5,20 @@ import { namespace, getConnectionOptions } from 'common/lib/temporal-connection'
 
 async function run() {
   const connection = await NativeConnection.connect(getConnectionOptions())
-  const worker = await Worker.create({
-    workflowsPath: require.resolve('../../../packages/workflows/'),
-    activities,
-    connection,
-    namespace,
-    taskQueue,
-  })
+  try {
+    const worker = await Worker.create({
+      workflowsPath: require.resolve('../../../packages/workflows/'),
+      activities,
+      connection,
+      namespace,
+      taskQueue,
+    })
 
-  await worker.run()
+    await worker.run()
+  } finally {
+    // Close the connection once the worker has stopped
+    await connection.close()
+  }
 }
 
 run().catch((err) => {

--- a/hello-world-mtls/src/worker.ts
+++ b/hello-world-mtls/src/worker.ts
@@ -34,18 +34,21 @@ async function run({
       },
     },
   });
+  try {
+    const worker = await Worker.create({
+      connection,
+      namespace,
+      workflowsPath: require.resolve('./workflows'),
+      activities,
+      taskQueue,
+    });
+    console.log('Worker connection successfully established');
 
-  const worker = await Worker.create({
-    connection,
-    namespace,
-    workflowsPath: require.resolve('./workflows'),
-    activities,
-    taskQueue,
-  });
-  console.log('Worker connection successfully established');
-
-  await worker.run();
-  await connection.close();
+    await worker.run();
+  } finally {
+    // Close the connection once the worker has stopped
+    await connection.close();
+  }
 }
 
 run(getEnv()).catch((err) => {

--- a/hello-world/src/worker.ts
+++ b/hello-world/src/worker.ts
@@ -11,25 +11,30 @@ async function run() {
     address: 'localhost:7233',
     // TLS and gRPC metadata configuration goes here.
   });
-  // Step 2: Register Workflows and Activities with the Worker.
-  const worker = await Worker.create({
-    connection,
-    namespace: 'default',
-    taskQueue: 'hello-world',
-    // Workflows are registered using a path as they run in a separate JS context.
-    workflowsPath: require.resolve('./workflows'),
-    activities,
-  });
+  try {
+    // Step 2: Register Workflows and Activities with the Worker.
+    const worker = await Worker.create({
+      connection,
+      namespace: 'default',
+      taskQueue: 'hello-world',
+      // Workflows are registered using a path as they run in a separate JS context.
+      workflowsPath: require.resolve('./workflows'),
+      activities,
+    });
 
-  // Step 3: Start accepting tasks on the `hello-world` queue
-  //
-  // The worker runs until it encounters an unexpected error or the process receives a shutdown signal registered on
-  // the SDK Runtime object.
-  //
-  // By default, worker logs are written via the Runtime logger to STDERR at INFO level.
-  //
-  // See https://typescript.temporal.io/api/classes/worker.Runtime#install to customize these defaults.
-  await worker.run();
+    // Step 3: Start accepting tasks on the `hello-world` queue
+    //
+    // The worker runs until it encounters an unexpected error or the process receives a shutdown signal registered on
+    // the SDK Runtime object.
+    //
+    // By default, worker logs are written via the Runtime logger to STDERR at INFO level.
+    //
+    // See https://typescript.temporal.io/api/classes/worker.Runtime#install to customize these defaults.
+    await worker.run();
+  } finally {
+    // Close the connection once the worker has stopped
+    await connection.close();
+  }
 }
 
 run().catch((err) => {

--- a/message-passing/execute-update/src/worker.ts
+++ b/message-passing/execute-update/src/worker.ts
@@ -5,13 +5,18 @@ async function run() {
   const connection = await NativeConnection.connect({
     address: 'localhost:7233',
   });
-  const worker = await Worker.create({
-    connection,
-    namespace: 'default',
-    taskQueue: 'my-task-queue',
-    workflowsPath: require.resolve('./workflows'),
-  });
-  await worker.run();
+  try {
+    const worker = await Worker.create({
+      connection,
+      namespace: 'default',
+      taskQueue: 'my-task-queue',
+      workflowsPath: require.resolve('./workflows'),
+    });
+    await worker.run();
+  } finally {
+    // Close the connection once the worker has stopped
+    await connection.close();
+  }
 }
 
 run().catch((err) => {

--- a/message-passing/introduction/src/worker.ts
+++ b/message-passing/introduction/src/worker.ts
@@ -6,14 +6,19 @@ async function run() {
   const connection = await wo.NativeConnection.connect({
     address: 'localhost:7233',
   });
-  const worker = await wo.Worker.create({
-    connection,
-    namespace: 'default',
-    taskQueue: 'my-task-queue',
-    workflowsPath: require.resolve('./workflows'),
-    activities,
-  });
-  await worker.run();
+  try {
+    const worker = await wo.Worker.create({
+      connection,
+      namespace: 'default',
+      taskQueue: 'my-task-queue',
+      workflowsPath: require.resolve('./workflows'),
+      activities,
+    });
+    await worker.run();
+  } finally {
+    // Close the connection once the worker has stopped
+    await connection.close();
+  }
 }
 
 run().catch((err) => {


### PR DESCRIPTION
## What was changed

- Add a finally block containing `await connection.close()` for all native connections that are explicitly created from the code. Not doing so prevents the worker process from exiting.