### PR TITLE
fix: added husky to package.json in nextjs ecommerce app

### DIFF
--- a/nextjs-ecommerce-oneclick/package.json
+++ b/nextjs-ecommerce-oneclick/package.json
@@ -41,6 +41,7 @@
     "eslint-config-next": "^15.0.4",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-deprecation": "^3.0.0",
+    "husky": "^7.0.2",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.3.5",
     "prettier": "^3.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2052,6 +2052,9 @@ importers:
       eslint-plugin-deprecation:
         specifier: ^3.0.0
         version: 3.0.0(eslint@8.57.1)(typescript@5.7.2)
+      husky:
+        specifier: ^7.0.2
+        version: 7.0.4
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5


### PR DESCRIPTION
## What was changed
Husky was added to the NextJS Ecommerce App package.json dev dependencies

## Why?
Without this here, I got an error that said I need husky.

## How was this tested
I ran `npm install` after adding this, and the error went away.

