### PR TITLE
Revise coverage of API Key authentication

### DIFF
--- a/hello-world-mtls/README.md
+++ b/hello-world-mtls/README.md
@@ -60,7 +60,7 @@ npm run workflow to run the Workflow
 - **Address**: Make sure to configure the mTLS endpoint as it appears in Temporal Cloud's web interface,
   e.g. `${namespace}.tmprl.cloud:7233`.
 
-  Note that endpoints of the form `${region}.${provider}.api.tmprl.cloud:7233` only support [API Key authentication](#connection-to-a-temporal-cloud-namespace-with-api-key-authentication). They will not work with mTLS authentication.
+  Note that endpoints of the form `${region}.${provider}.api.temporal.io:7233` only support [API Key authentication](#connection-to-a-temporal-cloud-namespace-with-api-key-authentication). They will not work with mTLS authentication.
 
 - **Server Root CA Certificate**: When connecting to Temporal Cloud, you generally do not need to
   provide a Root CA certificate to your Clients and Workers, as Temporal Cloud server certificates
@@ -75,8 +75,9 @@ regarding usage of mTLS authentication with Temporal Cloud.
 - **Namespace**: Make sure to configure the namespace as it appears in Temporal Cloud's web interface.
   It will look something like `my-application.abc45`.
 
-- **Address**: Make sure to configure the TLS endpoint as it appears in Temporal Cloud's web interface.
-  It will look something like `${region}.${provider}.api.tmprl.cloud:7233`.
+- **Address**: Make sure to configure the API Key endpoint as it appears in Temporal Cloud's web interface.
+  As noted above, this will be different from the address you'd use with mTLS. With API Key authentication, 
+  this endpoint address will look something like `${region}.${provider}.api.temporal.io:7233`.
 
 - **Server Root CA Certificate**: When connecting to Temporal Cloud, you generally do not need to
   provide a Root CA certificate to your Clients and Workers, as Temporal Cloud server certificates

--- a/hello-world-mtls/README.md
+++ b/hello-world-mtls/README.md
@@ -76,7 +76,7 @@ regarding usage of mTLS authentication with Temporal Cloud.
   It will look something like `my-application.abc45`.
 
 - **Address**: Make sure to configure the API Key endpoint as it appears in Temporal Cloud's web interface.
-  As noted above, this will be different from the address you'd use with mTLS. With API Key authentication, 
+  As noted above, this will be different from the address you'd use with mTLS. With API Key authentication,
   this endpoint address will look something like `${region}.${provider}.api.temporal.io:7233`.
 
 - **Server Root CA Certificate**: When connecting to Temporal Cloud, you generally do not need to

--- a/hello-world-mtls/src/client.ts
+++ b/hello-world-mtls/src/client.ts
@@ -21,7 +21,7 @@ async function run() {
           key: clientKey,
         },
     },
-    apiKey: apiKey,
+    apiKey,
     metadata: {
       'temporal-namespace': namespace,
     },

--- a/hello-world-mtls/src/client.ts
+++ b/hello-world-mtls/src/client.ts
@@ -21,8 +21,12 @@ async function run() {
           key: clientKey,
         },
     },
-    apiKey,
+    apiKey: apiKey,
+    metadata: {
+      'temporal-namespace': namespace,
+    },
   });
+
   const client = new Client({ connection, namespace });
 
   // Run example workflow and await its completion

--- a/hello-world-mtls/src/helpers.ts
+++ b/hello-world-mtls/src/helpers.ts
@@ -29,7 +29,7 @@ export async function getEnv(): Promise<Env> {
     clientCert: await maybeReadFileAsBuffer(process.env.TEMPORAL_CLIENT_CERT_PATH),
     clientKey: await maybeReadFileAsBuffer(process.env.TEMPORAL_CLIENT_KEY_PATH),
 
-    apiKey: process.env.TEMPORAL_CLIENT_KEY_PATH,
+    apiKey: process.env.TEMPORAL_CLIENT_API_KEY,
 
     taskQueue: process.env.TEMPORAL_TASK_QUEUE || 'hello-world-tls',
   };

--- a/hello-world-mtls/src/worker.ts
+++ b/hello-world-mtls/src/worker.ts
@@ -22,7 +22,10 @@ async function run() {
           key: clientKey,
         },
     },
-    apiKey,
+    apiKey: apiKey,
+    metadata: {
+      'temporal-namespace': namespace,
+    },
   });
 
   try {

--- a/hello-world-mtls/src/worker.ts
+++ b/hello-world-mtls/src/worker.ts
@@ -22,7 +22,7 @@ async function run() {
           key: clientKey,
         },
     },
-    apiKey: apiKey,
+    apiKey,
     metadata: {
       'temporal-namespace': namespace,
     },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I changed the name of the environment variable used to reference the API key from `TEMPORAL_CLIENT_KEY_PATH` to `TEMPORAL_CLIENT_API_KEY `. I also updated the `README.md` to better reflect the endpoint addresses currently shown for mTLS and API keys in Temporal Cloud. Finally, I updated the two source files that establish a connection to the Temporal Service so that they set the `apiKey` attribute and metadata, as per [the documentation](https://docs.temporal.io/cloud/api-keys#typescript-sdk-v-1100) for post-1.10.0 releases of the TypeScript SDK.

## Why?
<!-- Tell your future self why have you made these changes -->
This makes the code follow what's documented in the README, which specifies the `TEMPORAL_CLIENT_API_KEY` environment variable for the API key. The `TEMPORAL_CLIENT_KEY_PATH` environment variable is already used to specify the location of the TLS private key, which leads me to believe that its reuse on line 32 was a mistake.

Also, the explanation in the README about what endpoint addresses look like did not reflect those shown in Temporal Cloud. My change updates the description to match what I see in the UI.

Finally, my connections to Temporal Cloud were rejected as unauthorized because the code wasn't configured correctly for a Client using API Key for authentication.

## Checklist
<!--- add/delete as needed --->

1. Closes: N/A

2. How was this tested: I tested both the mTLS and API key authentication scenarios using my Temporal Cloud account.

