### PR TITLE
fix/readme: fix broken link to docs

### DIFF
--- a/sinks/README.md
+++ b/sinks/README.md
@@ -2,7 +2,7 @@
 
 This project demonstrates the Sinks API for alerting.
 
-The [Logging docs](https://docs.temporal.io/dev-guide/typescript/observability#logging) explains some of the code in this sample.
+The [Logging docs](https://docs.temporal.io/develop/typescript/observability#implementing-custom-logging-like-features-based-on-workflow-sinks) explains some of the code in this sample.
 
 ### Running this sample
 


### PR DESCRIPTION
## What was changed
Fixed the broken link to the docs.

## Why?
Broken links cause
