### PR TITLE
Do not configure NPM workspace on the root project

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,5 @@
         }
       }
     }
-  },
-  "workspaces": [
-    "*",
-    "message-passing/*",
-    "monorepo-folders/packages/*",
-    "food-delivery/packages/*",
-    "food-delivery/apps/*"
-  ]
+  }
 }


### PR DESCRIPTION
## What was changed

- Do not configure NPM workspace on the root repository. We specifically want
  PNPM and NPM/YARN configuration to differ on this regard, so that the repository
  can be used either as a monorepo (e.g. `pnpm install` on the root directory) or
  as individual projects (e.g. `cd hello-world ; npm install`, without installing
  dependencies on the whole repo).

  That's how the PNPM setup was initially created. I added that at some point to
  test something, and may have I forgot to remove before the final commit.
