### PR TITLE
refactor(expense): use wf.condition for signal-or-timeout logic

### DIFF
--- a/expense/src/workflows.ts
+++ b/expense/src/workflows.ts
@@ -19,8 +19,12 @@ const { createExpense, payment } = wf.proxyActivities<typeof activities>({
 
 export async function timeoutOrUserAction(timeout: Duration): Promise<ExpenseStatus> {
   let status: ExpenseStatus = ExpenseStatus.TIMED_OUT;
-  wf.setHandler(approveSignal, () => { status = ExpenseStatus.APPROVED; });
-  wf.setHandler(rejectSignal, () => { status = ExpenseStatus.REJECTED; });
+  wf.setHandler(approveSignal, () => {
+    status = ExpenseStatus.APPROVED;
+  });
+  wf.setHandler(rejectSignal, () => {
+    status = ExpenseStatus.REJECTED;
+  });
   await wf.condition(() => status !== ExpenseStatus.TIMED_OUT, timeout);
 
   return status;

--- a/expense/src/workflows.ts
+++ b/expense/src/workflows.ts
@@ -17,12 +17,13 @@ const { createExpense, payment } = wf.proxyActivities<typeof activities>({
   startToCloseTimeout: '5 minutes',
 });
 
-export function timeoutOrUserAction(timeout: Duration): Promise<ExpenseStatus> {
-  return new Promise((resolve, reject) => {
-    wf.setHandler(approveSignal, () => resolve(ExpenseStatus.APPROVED));
-    wf.setHandler(rejectSignal, () => resolve(ExpenseStatus.REJECTED));
-    wf.sleep(timeout).then(() => resolve(ExpenseStatus.TIMED_OUT), reject);
-  });
+export async function timeoutOrUserAction(timeout: Duration): Promise<ExpenseStatus> {
+  let status: ExpenseStatus = ExpenseStatus.TIMED_OUT;
+  wf.setHandler(approveSignal, () => { status = ExpenseStatus.APPROVED; });
+  wf.setHandler(rejectSignal, () => { status = ExpenseStatus.REJECTED; });
+  await wf.condition(() => status !== ExpenseStatus.TIMED_OUT, timeout);
+
+  return status;
 }
 
 export async function expense(expenseId: string, timeout: Duration = '10s'): Promise<{ status: ExpenseStatus }> {


### PR DESCRIPTION
## What was changed
Replaced the Promise-based timeout logic with async/await + wf.condition.

## Why?
- `wf.condition` seems more idiomatic and a better fit for the problem.
- the promise variant could potentially resolve or reject multiple times.
- the promise variant could continue sleeping even after a signal was received.

## Checklist
1. Closes N/A — small cleanup, no issue needed
2. How was this tested: ran example and observed same results
3. Any docs updates needed? No