### PR TITLE
Nexus samples: use business IDs for workflow IDs

### DIFF
--- a/nexus-cancellation/src/service/handler.ts
+++ b/nexus-cancellation/src/service/handler.ts
@@ -6,7 +6,7 @@ import { helloWorkflow } from './workflows';
 /**
  * Creates a business-meaningful ID that is used to dedupe workflow starts
  * from the `helloService.hello` Nexus Operation.
- * 
+ *
  * @param input HelloInput
  * @returns A workflow ID derived from the Nexus Operation input.
  */

--- a/nexus-cancellation/src/service/handler.ts
+++ b/nexus-cancellation/src/service/handler.ts
@@ -3,6 +3,13 @@ import * as temporalNexus from '@temporalio/nexus';
 import { helloService, HelloInput, HelloOutput } from '../api';
 import { helloWorkflow } from './workflows';
 
+/**
+ * Creates a business-meaningful ID that is used to dedupe workflow starts
+ * from the `helloService.hello` Nexus Operation.
+ * 
+ * @param input HelloInput
+ * @returns A workflow ID derived from the Nexus Operation input.
+ */
 function workflowIdForHello(input: HelloInput): string {
   return `hello-${input.language}-${input.name}`;
 }

--- a/nexus-cancellation/src/service/handler.ts
+++ b/nexus-cancellation/src/service/handler.ts
@@ -1,8 +1,11 @@
-import { randomUUID } from 'crypto';
 import * as nexus from 'nexus-rpc';
 import * as temporalNexus from '@temporalio/nexus';
 import { helloService, HelloInput, HelloOutput } from '../api';
 import { helloWorkflow } from './workflows';
+
+function workflowIdForHello(input: HelloInput): string {
+  return `hello-${input.language}-${input.name}`;
+}
 
 export const helloServiceHandler = nexus.serviceHandler(helloService, {
   hello: new temporalNexus.WorkflowRunOperationHandler<HelloInput, HelloOutput>(
@@ -16,9 +19,8 @@ export const helloServiceHandler = nexus.serviceHandler(helloService, {
         args: [input],
 
         // Workflow IDs should typically be business-meaningful IDs and are used to dedupe workflow starts.
-        // For this example, we're using the request ID allocated by Temporal when the caller workflow schedules
-        // the operation, this ID is guaranteed to be stable across retries of this operation.
-        workflowId: ctx.requestId ?? randomUUID(),
+        // For this example, the workflow handles the greeting request for a given person and language pair.
+        workflowId: workflowIdForHello(input),
 
         // Task queue defaults to the task queue this Operation is handled on.
       });

--- a/nexus-hello/src/service/handler.ts
+++ b/nexus-hello/src/service/handler.ts
@@ -7,7 +7,7 @@ import { helloWorkflow } from './workflows';
 /**
  * Creates a business-meaningful ID that is used to dedupe workflow starts
  * from the `helloService.hello` Nexus Operation.
- * 
+ *
  * @param input HelloInput
  * @returns A workflow ID derived from the Nexus Operation input.
  */

--- a/nexus-hello/src/service/handler.ts
+++ b/nexus-hello/src/service/handler.ts
@@ -1,9 +1,12 @@
 // @@@SNIPSTART typescript-nexus-hello-service-handler
-import { randomUUID } from 'crypto';
 import * as nexus from 'nexus-rpc';
 import * as temporalNexus from '@temporalio/nexus';
 import { helloService, EchoInput, EchoOutput, HelloInput, HelloOutput } from '../api';
 import { helloWorkflow } from './workflows';
+
+function workflowIdForHello(input: HelloInput): string {
+  return `hello-${input.language}-${input.name}`;
+}
 
 export const helloServiceHandler = nexus.serviceHandler(helloService, {
   echo: async (ctx, input: EchoInput): Promise<EchoOutput> => {
@@ -27,9 +30,8 @@ export const helloServiceHandler = nexus.serviceHandler(helloService, {
         args: [input],
 
         // Workflow IDs should typically be business-meaningful IDs and are used to dedupe workflow starts.
-        // For this example, we're using the request ID allocated by Temporal when the caller workflow schedules
-        // the operation, this ID is guaranteed to be stable across retries of this operation.
-        workflowId: ctx.requestId ?? randomUUID(),
+        // For this example, the workflow handles the greeting request for a given person and language pair.
+        workflowId: workflowIdForHello(input),
 
         // Task queue defaults to the task queue this Operation is handled on.
       });

--- a/nexus-hello/src/service/handler.ts
+++ b/nexus-hello/src/service/handler.ts
@@ -4,6 +4,13 @@ import * as temporalNexus from '@temporalio/nexus';
 import { helloService, EchoInput, EchoOutput, HelloInput, HelloOutput } from '../api';
 import { helloWorkflow } from './workflows';
 
+/**
+ * Creates a business-meaningful ID that is used to dedupe workflow starts
+ * from the `helloService.hello` Nexus Operation.
+ * 
+ * @param input HelloInput
+ * @returns A workflow ID derived from the Nexus Operation input.
+ */
 function workflowIdForHello(input: HelloInput): string {
   return `hello-${input.language}-${input.name}`;
 }


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

Stop using the Nexus request ID as the backing workflow ID. Build a meaningful business ID from the operation input.

## Why?
<!-- Tell your future self why have you made these changes -->

Our samples should reflect best practices around creating meaningful IDs. Part of https://github.com/temporalio/features/issues/692.

