### PR TITLE
Add tool-registry-incident-triage sample

### DIFF
--- a/.scripts/list-of-samples.json
+++ b/.scripts/list-of-samples.json
@@ -47,6 +47,7 @@
     "state",
     "timer-examples",
     "timer-progress",
+    "tool-registry-incident-triage",
     "vscode-debugger",
     "worker-specific-task-queues",
     "worker-versioning"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ and you'll be given the list of sample options.
 - [**Activity Cancellation and Heartbeating**](./activities-cancellation-heartbeating): Heartbeat progress for long running activities and cancel them.
 - [**Dependency Injection**](./activities-dependency-injection): Share dependencies between activities (for example, when you need to initialize a database connection once and then pass it to multiple activities).
 - [**Worker-Specific Task Queues**](./worker-specific-task-queues): Use a unique task queue per Worker to have certain Activities only run on that specific Worker. For instance for a file processing Workflow, where the first Activity is downloading a file, and subsequent Activities need to operate on that file. (If multiple Workers were on the same queue, subsequent Activities may get run on different machines that don't have the downloaded file.)
+- [**Tool Registry: Incident Triage**](./tool-registry-incident-triage): LLM-driven incident triage activity using `@temporalio/tool-registry`. Demonstrates `agenticSession`, MCP HTTP integration, human-in-the-loop via a companion workflow, and a testable activity refactor (`buildTriageRegistry` + `TriageDeps`).
 
 #### Nexus APIs
 

--- a/tool-registry-incident-triage/README.md
+++ b/tool-registry-incident-triage/README.md
@@ -1,0 +1,38 @@
+# TypeScript: incident-triage tool-registry sample
+
+Demonstrates `@temporalio/tool-registry` end-to-end: long-running `agenticSession` activity, MCP HTTP integration, human-in-the-loop via companion workflow, and a testable activity refactor.
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `types.ts` | `AlertPayload`, `TriageResult`, `ApprovalRequest`, `ApprovalResponse` types. |
+| `activities/triage.ts` | The activity. `TriageDeps` interface, `buildTriageRegistry(alert, session, deps)` returning `{ registry, getResult }`, and the activity entrypoint that wires production deps. |
+| `workflows/triage.ts` | Workflow that schedules the activity. |
+| `workflows/approval.ts` | Companion HITL workflow: deterministic ID per alert, two signals, one query. |
+| `worker.ts` | Worker registration. |
+| `client.ts` | Demo client to start a workflow. |
+| `triage_activity.test.ts` | Vitest unit tests demonstrating `MockProvider` + `TriageDeps` pattern. Run: `vitest run`. |
+
+## Run
+
+```bash
+# 1. Temporal dev server (separate terminal)
+temporal server start-dev
+
+# 2. Env
+export ANTHROPIC_API_KEY=sk-ant-...
+export PROM_MCP=http://localhost:7070/mcp
+export K8S_MCP=http://localhost:7071/mcp
+
+# 3. Worker
+npm run worker
+
+# 4. Client
+npm run start
+```
+
+## Requires
+
+- `@temporalio/tool-registry` (currently the `feat/tool-registry` branch).
+- `@anthropic-ai/sdk` peer dep.

--- a/tool-registry-incident-triage/package.json
+++ b/tool-registry-incident-triage/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "temporal-tool-registry-incident-triage",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc --build",
+    "build.watch": "tsc --build --watch",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint .",
+    "start": "ts-node src/worker.ts",
+    "start.watch": "nodemon src/worker.ts",
+    "workflow": "ts-node src/client.ts",
+    "test": "mocha --exit --require ts-node/register --require source-map-support/register src/mocha/*.test.ts"
+  },
+  "nodemonConfig": {
+    "execMap": {
+      "ts": "ts-node"
+    },
+    "ext": "ts",
+    "watch": [
+      "src"
+    ]
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.40.0",
+    "@temporalio/activity": "^1.15.0",
+    "@temporalio/client": "^1.15.0",
+    "@temporalio/tool-registry": "file:../../sdk-typescript/packages/tool-registry",
+    "@temporalio/worker": "^1.15.0",
+    "@temporalio/workflow": "^1.15.0"
+  },
+  "devDependencies": {
+    "@temporalio/testing": "^1.15.0",
+    "@tsconfig/node22": "^22.0.0",
+    "@types/mocha": "8.x",
+    "@types/node": "^22.9.1",
+    "mocha": "8.x",
+    "nodemon": "^3.1.7",
+    "prettier": "^3.4.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/tool-registry-incident-triage/src/activities/triage.ts
+++ b/tool-registry-incident-triage/src/activities/triage.ts
@@ -1,0 +1,317 @@
+/**
+ * triageIncidentActivity — the agentic loop.
+ *
+ * Opens an AgenticSession (heartbeat-checkpointed), wires up:
+ *   - Prometheus tools sourced from the mcp-prometheus sidecar (localhost:7071)
+ *   - Kubernetes tools sourced from the mcp-server-kubernetes sidecar (localhost:7072)
+ *   - Per-language tools defined here: propose_remediation, request_human_approval,
+ *     execute_remediation, report_resolved, report_unresolved
+ *
+ * The agent diagnoses the alert, proposes a remediation, requests human approval
+ * (which signalWithStart's the companion approvalWorkflow), and — only if
+ * approved — executes the remediation. Reports either resolved or unresolved.
+ *
+ * Structure:
+ *   - `buildTriageRegistry()` returns the registry + a `getResult()` getter.
+ *     Pure-ish: takes all I/O dependencies as injected functions so unit tests
+ *     can substitute them.
+ *   - `triageIncidentActivity()` opens the agenticSession, calls
+ *     buildTriageRegistry with real deps, then runs the LLM loop.
+ */
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { Connection, Client } from "@temporalio/client";
+import { ToolRegistry, agenticSession, type AgenticSession } from "@temporalio/tool-registry";
+import {
+  approvalWorkflow,
+  approvalRequestSignal,
+} from "../workflows/approval";
+import type {
+  AlertPayload,
+  TriageResult,
+  ProposedRemediation,
+  ApprovalRequest,
+  ApprovalResponse,
+} from "../types";
+
+const execAsync = promisify(exec);
+
+const SYSTEM_PROMPT = `You are an SRE on-call agent triaging a production alert.
+
+You have these tools (sourced from MCP sidecars + per-language helpers):
+  - prometheus_query(query)            instant PromQL query
+  - prometheus_query_range(query, start, end, step)
+  - prometheus_alerts()                what is currently firing
+  - kubectl_get(resource, namespace?)  list K8s resources
+  - kubectl_describe(resource, name, namespace?)
+  - kubectl_logs(pod, namespace, tail?)
+  - propose_remediation(action, justification)   record but do NOT execute
+  - request_human_approval(message, diagnosis, proposedAction)
+                                       blocks until operator says approve|reject
+  - execute_remediation(action)        ONLY callable AFTER approval was approved.
+                                       Pass the same action you got approved.
+  - report_resolved(summary)           ends the loop with status=resolved
+  - report_unresolved(summary)         ends the loop with status=unresolved
+
+Workflow:
+  1. Read the alert. Use prometheus_query to confirm the symptom is currently true.
+  2. Use kubectl_get/describe/logs and prometheus_query_range to find root cause.
+  3. propose_remediation with a specific action (e.g., "kubectl rollout restart deploy/api -n demo-app").
+  4. request_human_approval, attaching your diagnosis and the proposed action.
+  5. If approved: execute_remediation, then prometheus_query to verify the symptom is gone, then report_resolved.
+  6. If rejected: report_unresolved with the operator's reason.
+
+Be terse. Conversation history is heartbeated to Temporal — keep tool inputs short.`;
+
+// ── Injectable dependencies (override in tests) ────────────────────────────
+
+export interface TriageDeps {
+  /** Returns the tool catalog at the given MCP server URL. */
+  mcpListTools: (baseUrl: string) => Promise<{ name: string; description?: string; inputSchema?: any }[]>;
+  /** Calls a tool on the given MCP server URL, returns the (text-joined) result. */
+  mcpCallTool: (baseUrl: string, name: string, args: Record<string, unknown>) => Promise<string>;
+  /** Bridges request_human_approval to the companion approvalWorkflow. */
+  requestHumanApproval: (alert: AlertPayload, request: ApprovalRequest) => Promise<ApprovalResponse>;
+  /** Runs an approved kubectl/etc command. */
+  execShellCommand: (cmd: string) => Promise<{ stdout: string; stderr: string }>;
+}
+
+export const defaultDeps: TriageDeps = {
+  mcpListTools: async (baseUrl) => {
+    const res = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    const json = await res.json() as any;
+    if (json.error) throw new Error(`mcp tools/list ${baseUrl}: ${json.error.message}`);
+    return json.result?.tools ?? [];
+  },
+  mcpCallTool: async (baseUrl, name, args) => {
+    const res = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method: "tools/call", params: { name, arguments: args } }),
+    });
+    const json = await res.json() as any;
+    if (json.error) return `MCP error: ${json.error.message}`;
+    const blocks = json.result?.content ?? [];
+    return blocks.map((b: any) => b.text ?? "").join("\n");
+  },
+  requestHumanApproval: realRequestHumanApproval,
+  execShellCommand: async (cmd) => execAsync(cmd, { timeout: 60_000 }),
+};
+
+const PROM_MCP = process.env.MCP_PROMETHEUS_URL ?? "http://localhost:7071/";
+const K8S_MCP = process.env.MCP_KUBERNETES_URL ?? "http://localhost:7072/";
+
+// ── Registry builder (testable surface) ──────────────────────────────────────
+
+/**
+ * Build a populated `ToolRegistry` plus a `getResult()` accessor for the final
+ * verdict. Pure modulo the injected `deps` — `MockProvider.runLoop(messages, registry)`
+ * can drive the registry without any real MCP, Temporal, or shell dependency.
+ */
+export async function buildTriageRegistry(
+  alert: AlertPayload,
+  session: Pick<AgenticSession, "results">,
+  deps: TriageDeps,
+  endpoints: { promMcp: string; k8sMcp: string } = { promMcp: PROM_MCP, k8sMcp: K8S_MCP },
+): Promise<{ registry: ToolRegistry; getResult: () => TriageResult | null }> {
+  const registry = new ToolRegistry();
+
+  // MCP-sourced tools.
+  const promTools = await deps.mcpListTools(endpoints.promMcp).catch(() => []);
+  const k8sTools = await deps.mcpListTools(endpoints.k8sMcp).catch(() => []);
+  for (const t of promTools) {
+    registry.define(
+      { name: t.name, description: t.description ?? "", input_schema: t.inputSchema ?? { type: "object" } },
+      (args) => deps.mcpCallTool(endpoints.promMcp, t.name, args),
+    );
+  }
+  for (const t of k8sTools) {
+    registry.define(
+      { name: t.name, description: t.description ?? "", input_schema: t.inputSchema ?? { type: "object" } },
+      (args) => deps.mcpCallTool(endpoints.k8sMcp, t.name, args),
+    );
+  }
+
+  // Per-language tools.
+  const remediations: ProposedRemediation[] = [];
+  let approvedAction: string | null = null;
+  let final: TriageResult | null = null;
+
+  registry.define(
+    {
+      name: "propose_remediation",
+      description: "Record a remediation you would apply. Does NOT execute it.",
+      input_schema: {
+        type: "object",
+        properties: { action: { type: "string" }, justification: { type: "string" } },
+        required: ["action", "justification"],
+      },
+    },
+    (inp) => {
+      const r = { action: String(inp.action), justification: String(inp.justification) };
+      remediations.push(r);
+      session.results.push({ kind: "remediation", ...r });
+      return "recorded";
+    },
+  );
+
+  registry.define(
+    {
+      name: "request_human_approval",
+      description: "Block until operator decides. Returns JSON {decision, reason}.",
+      input_schema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+          diagnosis: { type: "string" },
+          proposedAction: { type: "string" },
+        },
+        required: ["message", "diagnosis", "proposedAction"],
+      },
+    },
+    async (inp) => {
+      const req: ApprovalRequest = {
+        message: String(inp.message),
+        diagnosis: String(inp.diagnosis),
+        proposedAction: String(inp.proposedAction),
+      };
+      const response = await deps.requestHumanApproval(alert, req);
+      if (response.decision === "approved") {
+        approvedAction = req.proposedAction;
+      }
+      session.results.push({ kind: "approval", ...response });
+      return JSON.stringify(response);
+    },
+  );
+
+  registry.define(
+    {
+      name: "execute_remediation",
+      description: "Execute the previously-approved action. Errors if no approval has been granted.",
+      input_schema: {
+        type: "object",
+        properties: { action: { type: "string" } },
+        required: ["action"],
+      },
+    },
+    async (inp) => {
+      const action = String(inp.action);
+      if (approvedAction === null) {
+        return "ERROR: no approval has been granted. Call request_human_approval first.";
+      }
+      if (action !== approvedAction) {
+        return `ERROR: requested action does not match approved action. Approved: ${approvedAction}`;
+      }
+      try {
+        const { stdout, stderr } = await deps.execShellCommand(action);
+        session.results.push({ kind: "executed", action, stdout: stdout.slice(0, 2000), stderr: stderr.slice(0, 2000) });
+        return (stdout || stderr || "ok").slice(0, 4000);
+      } catch (e: any) {
+        return `EXEC ERROR: ${e.message}`;
+      }
+    },
+  );
+
+  registry.define(
+    {
+      name: "report_resolved",
+      description: "Ends the loop with status=resolved.",
+      input_schema: { type: "object", properties: { summary: { type: "string" } }, required: ["summary"] },
+    },
+    (inp) => {
+      final = { status: "resolved", summary: String(inp.summary), remediations };
+      session.results.push({ kind: "final", ...final });
+      return "ok";
+    },
+  );
+
+  registry.define(
+    {
+      name: "report_unresolved",
+      description: "Ends the loop with status=unresolved.",
+      input_schema: { type: "object", properties: { summary: { type: "string" } }, required: ["summary"] },
+    },
+    (inp) => {
+      final = { status: "unresolved", summary: String(inp.summary), remediations };
+      session.results.push({ kind: "final", ...final });
+      return "ok";
+    },
+  );
+
+  return { registry, getResult: () => final };
+}
+
+/** Build the initial user prompt the agent sees. */
+export function buildPrompt(alert: AlertPayload): string {
+  return (
+    `Alert fired: ${alert.labels["alertname"]} on ${alert.labels["service"] ?? "unknown"}.\n` +
+    `Summary: ${alert.annotations["summary"] ?? "(none)"}\n` +
+    `Description: ${alert.annotations["description"] ?? "(none)"}\n` +
+    `Runbook hint: ${alert.labels["runbook"] ?? "(none)"}\n\n` +
+    `Investigate, propose, get approval, and either fix or report unresolved.`
+  );
+}
+
+// ── Activity entrypoint ─────────────────────────────────────────────────────
+
+export async function triageIncidentActivity(alert: AlertPayload, deps: TriageDeps = defaultDeps): Promise<TriageResult> {
+  return agenticSession(async (session) => {
+    const { registry, getResult } = await buildTriageRegistry(alert, session, deps);
+
+    await session.runToolLoop({
+      registry,
+      provider: "anthropic",
+      system: SYSTEM_PROMPT,
+      prompt: buildPrompt(alert),
+    });
+
+    const final = getResult();
+    if (!final) {
+      throw new Error("Agent ended the loop without calling report_resolved or report_unresolved");
+    }
+    return final;
+  });
+}
+
+// ── Real HITL bridge ─────────────────────────────────────────────────────────
+
+/**
+ * signalWithStart's `approvalWorkflow` with deterministic ID per alert group.
+ * Returns the operator's decision (decision/reason) which the agent observes
+ * as the tool result.
+ */
+async function realRequestHumanApproval(alert: AlertPayload, request: ApprovalRequest): Promise<ApprovalResponse> {
+  const apiKey = process.env.TEMPORAL_API_KEY;
+  const address = process.env.TEMPORAL_ADDRESS;
+  const namespace = process.env.TEMPORAL_NAMESPACE;
+  if (!address || !namespace || !apiKey) {
+    throw new Error("Missing TEMPORAL_ADDRESS/NAMESPACE/API_KEY for HITL bridge");
+  }
+
+  const connection = await Connection.connect({
+    address,
+    tls: {},
+    metadata: { Authorization: `Bearer ${apiKey}` },
+  });
+  const client = new Client({ connection, namespace });
+
+  const key = `${alert.labels["alertname"] ?? "unknown"}-${alert.labels["service"] ?? "unknown"}`;
+  const approvalWorkflowId = `approval-${key.toLowerCase()}`;
+  const taskQueue = process.env.TEMPORAL_TASK_QUEUE ?? "triage-typescript";
+
+  const handle = await client.workflow.signalWithStart(approvalWorkflow, {
+    workflowId: approvalWorkflowId,
+    taskQueue,
+    args: [key],
+    signal: approvalRequestSignal,
+    signalArgs: [request],
+  });
+
+  const response = (await handle.result()) as ApprovalResponse;
+  await connection.close();
+  return response;
+}

--- a/tool-registry-incident-triage/src/activities/triage.ts
+++ b/tool-registry-incident-triage/src/activities/triage.ts
@@ -20,6 +20,7 @@
  */
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
+import { heartbeat } from "@temporalio/activity";
 import { Connection, Client } from "@temporalio/client";
 import { WorkflowIdConflictPolicy } from "@temporalio/common";
 import { ToolRegistry, agenticSession, type AgenticSession } from "@temporalio/tool-registry";
@@ -316,7 +317,16 @@ async function realRequestHumanApproval(alert: AlertPayload, request: ApprovalRe
     workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
   });
 
-  const response = (await handle.result()) as ApprovalResponse;
-  await connection.close();
-  return response;
+  // Heartbeat every 30 seconds while waiting on the approval workflow.
+  // agenticSession only heartbeats between LLM turns, so a multi-hour
+  // operator wait inside this handler would otherwise trigger heartbeat
+  // timeout in 120s and kill the activity.
+  const ticker = setInterval(() => heartbeat(), 30_000);
+  try {
+    const response = (await handle.result()) as ApprovalResponse;
+    return response;
+  } finally {
+    clearInterval(ticker);
+    await connection.close();
+  }
 }

--- a/tool-registry-incident-triage/src/activities/triage.ts
+++ b/tool-registry-incident-triage/src/activities/triage.ts
@@ -21,6 +21,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import { Connection, Client } from "@temporalio/client";
+import { WorkflowIdConflictPolicy } from "@temporalio/common";
 import { ToolRegistry, agenticSession, type AgenticSession } from "@temporalio/tool-registry";
 import {
   approvalWorkflow,
@@ -309,6 +310,10 @@ async function realRequestHumanApproval(alert: AlertPayload, request: ApprovalRe
     args: [key],
     signal: approvalRequestSignal,
     signalArgs: [request],
+    // If the activity retries while the approval workflow is still running,
+    // attach to the existing one rather than starting a new approval. The
+    // operator should not get a second prompt for the same incident.
+    workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
   });
 
   const response = (await handle.result()) as ApprovalResponse;

--- a/tool-registry-incident-triage/src/client.ts
+++ b/tool-registry-incident-triage/src/client.ts
@@ -1,0 +1,112 @@
+/**
+ * Client CLI for the TypeScript triage workers.
+ *
+ * Usage:
+ *   tsx client.ts pending                       # list pending approval workflows
+ *   tsx client.ts approve <workflow-id> <reason>
+ *   tsx client.ts reject  <workflow-id> <reason>
+ *   tsx client.ts trigger <alertname> <service> # post a synthetic alert (skips webhook)
+ */
+import { Client, Connection, type WorkflowExecutionInfo } from "@temporalio/client";
+import {
+  incidentTriageWorkflow,
+  alertUpdateSignal,
+} from "./workflows/triage";
+import {
+  approvalDecisionSignal,
+  pendingApprovalQuery,
+} from "./workflows/approval";
+import type { AlertPayload } from "./types";
+
+async function makeClient(): Promise<Client> {
+  const address = process.env.TEMPORAL_ADDRESS!;
+  const namespace = process.env.TEMPORAL_NAMESPACE!;
+  const apiKey = process.env.TEMPORAL_API_KEY!;
+  if (!address || !namespace || !apiKey) {
+    throw new Error("Missing TEMPORAL_ADDRESS / TEMPORAL_NAMESPACE / TEMPORAL_API_KEY");
+  }
+  const connection = await Connection.connect({
+    address,
+    tls: {},
+    metadata: { Authorization: `Bearer ${apiKey}` },
+  });
+  return new Client({ connection, namespace });
+}
+
+async function pending(): Promise<void> {
+  const client = await makeClient();
+  // Look for running approval-* workflows
+  const iter = client.workflow.list({ query: 'WorkflowType="approvalWorkflow" AND ExecutionStatus="Running"' });
+  let any = false;
+  for await (const wf of iter as AsyncIterable<WorkflowExecutionInfo>) {
+    any = true;
+    const handle = client.workflow.getHandle(wf.workflowId);
+    const req = await handle.query(pendingApprovalQuery).catch(() => null);
+    console.log(`\n${wf.workflowId} (${wf.startTime?.toISOString?.()})`);
+    if (req) {
+      console.log(`  message:  ${req.message}`);
+      console.log(`  diagnosis: ${req.diagnosis}`);
+      console.log(`  proposed:  ${req.proposedAction}`);
+      console.log(`  approve:   tsx client.ts approve ${wf.workflowId} "<reason>"`);
+      console.log(`  reject:    tsx client.ts reject  ${wf.workflowId} "<reason>"`);
+    } else {
+      console.log("  (workflow exists but agent has not requested approval yet)");
+    }
+  }
+  if (!any) console.log("(no pending approval workflows)");
+}
+
+async function decide(decision: "approved" | "rejected", workflowId: string, reason: string): Promise<void> {
+  const client = await makeClient();
+  const handle = client.workflow.getHandle(workflowId);
+  await handle.signal(approvalDecisionSignal, { decision, reason });
+  console.log(`signaled ${workflowId}: ${decision} — ${reason}`);
+}
+
+async function trigger(alertname: string, service: string): Promise<void> {
+  const client = await makeClient();
+  const taskQueue = process.env.TEMPORAL_TASK_QUEUE ?? "triage-typescript";
+  const workflowId = `triage-${alertname.toLowerCase()}-${service.toLowerCase()}`;
+  const alert: AlertPayload = {
+    status: "firing",
+    labels: { alertname, service, severity: "critical", runbook: "synthetic" },
+    annotations: {
+      summary: `Synthetic test alert for ${service}`,
+      description: `Triggered manually via 'client.ts trigger' to exercise the triage flow.`,
+    },
+    startsAt: new Date().toISOString(),
+  };
+  const handle = await client.workflow.signalWithStart(incidentTriageWorkflow, {
+    workflowId,
+    taskQueue,
+    args: [alert],
+    signal: alertUpdateSignal,
+    signalArgs: [alert],
+  });
+  console.log(`started triage workflow: ${handle.workflowId} on ${taskQueue}`);
+}
+
+const [, , cmd, ...args] = process.argv;
+
+(async () => {
+  switch (cmd) {
+    case "pending":
+      await pending();
+      break;
+    case "approve":
+      if (args.length < 2) throw new Error("Usage: client.ts approve <wfid> <reason>");
+      await decide("approved", args[0]!, args.slice(1).join(" "));
+      break;
+    case "reject":
+      if (args.length < 2) throw new Error("Usage: client.ts reject <wfid> <reason>");
+      await decide("rejected", args[0]!, args.slice(1).join(" "));
+      break;
+    case "trigger":
+      if (args.length < 2) throw new Error("Usage: client.ts trigger <alertname> <service>");
+      await trigger(args[0]!, args[1]!);
+      break;
+    default:
+      console.error("Usage: tsx client.ts <pending|approve|reject|trigger>");
+      process.exit(1);
+  }
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/tool-registry-incident-triage/src/mocha/triage_activity.test.ts
+++ b/tool-registry-incident-triage/src/mocha/triage_activity.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for the triage activity's tool registry.
+ *
+ * Drives the registry directly with `MockProvider.runLoop`, bypassing
+ * `agenticSession` (which would require a real Anthropic client). Asserts
+ * that the agent's tool-call sequence produces the expected final result.
+ *
+ * No API keys, no Temporal, no shell exec, no MCP HTTP. All stubbed via
+ * the injected `TriageDeps`.
+ */
+import { describe, it } from 'mocha';
+import assert from 'node:assert';
+import {
+  MockProvider,
+  ResponseBuilder,
+  type MockResponse,
+  type Message,
+} from '@temporalio/tool-registry';
+import { buildTriageRegistry, type TriageDeps } from '../activities/triage';
+import type { AlertPayload, ApprovalResponse } from '../types';
+
+const ALERT: AlertPayload = {
+  status: 'firing',
+  labels: { alertname: 'HighLatencyP99', service: 'api', runbook: 'rollback-or-scale' },
+  annotations: {
+    summary: "P99 latency on api > 1s",
+    description: 'P99 above threshold for 1m.',
+  },
+  startsAt: new Date().toISOString(),
+};
+
+function makeDeps(overrides: Partial<TriageDeps> = {}): TriageDeps {
+  return {
+    mcpListTools: async (baseUrl) =>
+      baseUrl.includes('7071')
+        ? [
+            {
+              name: 'prometheus_query',
+              description: 'instant PromQL query',
+              inputSchema: {
+                type: 'object',
+                properties: { query: { type: 'string' } },
+                required: ['query'],
+              },
+            },
+          ]
+        : [
+            {
+              name: 'kubectl_describe',
+              description: 'describe a k8s resource',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  resource: { type: 'string' },
+                  name: { type: 'string' },
+                  namespace: { type: 'string' },
+                },
+                required: ['resource', 'name'],
+              },
+            },
+          ],
+    mcpCallTool: async (_url, name, args) => `(mocked ${name} ${JSON.stringify(args)})`,
+    requestHumanApproval: async () => ({ decision: 'approved', reason: 'default-mock' }),
+    execShellCommand: async (cmd) => ({ stdout: `(mocked exec: ${cmd})`, stderr: '' }),
+    ...overrides,
+  };
+}
+
+async function drive(
+  deps: TriageDeps,
+  script: MockResponse[]
+): Promise<{ result: any; mcpResults: unknown[] }> {
+  const session = { results: [] as unknown[] };
+  const { registry, getResult } = await buildTriageRegistry(ALERT, session, deps);
+  const provider = new MockProvider(script);
+  const messages: Message[] = [{ role: 'user', content: 'test prompt' }];
+  await provider.runLoop(messages, registry);
+  return { result: getResult(), mcpResults: session.results };
+}
+
+describe('buildTriageRegistry — happy path', () => {
+  it('investigate, propose, approve, execute, report_resolved', async () => {
+    let approvalCalls = 0;
+    const deps = makeDeps({
+      requestHumanApproval: async () => {
+        approvalCalls++;
+        return { decision: 'approved', reason: 'go ahead' };
+      },
+    });
+    const action = 'kubectl rollout restart deploy/api -n demo-app';
+
+    const { result, mcpResults } = await drive(deps, [
+      ResponseBuilder.toolCall('prometheus_query', { query: "up{service='api'}" }),
+      ResponseBuilder.toolCall('kubectl_describe', {
+        resource: 'pod',
+        name: 'api-xyz',
+        namespace: 'demo-app',
+      }),
+      ResponseBuilder.toolCall('propose_remediation', {
+        action,
+        justification: 'leak; restart reclaims memory',
+      }),
+      ResponseBuilder.toolCall('request_human_approval', {
+        message: 'Restart api?',
+        diagnosis: 'memory leak',
+        proposedAction: action,
+      }),
+      ResponseBuilder.toolCall('execute_remediation', { action }),
+      ResponseBuilder.toolCall('report_resolved', { summary: 'restarted; latency normal' }),
+      ResponseBuilder.done('done'),
+    ]);
+
+    assert.strictEqual(result.status, 'resolved');
+    assert.match(result.summary, /restart/);
+    assert.strictEqual(result.remediations.length, 1);
+    assert.strictEqual(result.remediations[0].action, action);
+    assert.strictEqual(approvalCalls, 1);
+    const kinds = mcpResults.map((r: any) => r.kind);
+    assert.deepStrictEqual(kinds, ['remediation', 'approval', 'executed', 'final']);
+  });
+});
+
+describe('buildTriageRegistry — rejected approval', () => {
+  it("agent reports unresolved with operator's reason", async () => {
+    const deps = makeDeps({
+      requestHumanApproval: async (): Promise<ApprovalResponse> => ({
+        decision: 'rejected',
+        reason: 'off-hours; defer until tomorrow',
+      }),
+    });
+
+    const { result, mcpResults } = await drive(deps, [
+      ResponseBuilder.toolCall('propose_remediation', {
+        action: 'kubectl scale ...',
+        justification: 'transient',
+      }),
+      ResponseBuilder.toolCall('request_human_approval', {
+        message: 'Scale?',
+        diagnosis: 'transient',
+        proposedAction: 'kubectl scale ...',
+      }),
+      ResponseBuilder.toolCall('report_unresolved', { summary: 'operator deferred' }),
+      ResponseBuilder.done('done'),
+    ]);
+
+    assert.strictEqual(result.status, 'unresolved');
+    assert.match(result.summary, /deferred/);
+    const approval = mcpResults.find((r: any) => r.kind === 'approval') as any;
+    assert.strictEqual(approval?.decision, 'rejected');
+    assert.match(approval?.reason ?? '', /off-hours/);
+  });
+});
+
+describe('buildTriageRegistry — guard rails', () => {
+  it('execute_remediation refuses without prior approval', async () => {
+    const deps = makeDeps();
+    const { result } = await drive(deps, [
+      ResponseBuilder.toolCall('execute_remediation', { action: 'rm -rf /' }),
+      ResponseBuilder.toolCall('report_unresolved', { summary: 'tried to skip approval' }),
+      ResponseBuilder.done('done'),
+    ]);
+    assert.strictEqual(result.status, 'unresolved');
+  });
+
+  it('execute_remediation refuses when action does not match approved one', async () => {
+    let executedCmd: string | null = null;
+    const deps = makeDeps({
+      requestHumanApproval: async () => ({ decision: 'approved', reason: 'ok' }),
+      execShellCommand: async (cmd) => {
+        executedCmd = cmd;
+        return { stdout: 'ran', stderr: '' };
+      },
+    });
+
+    const { result } = await drive(deps, [
+      ResponseBuilder.toolCall('propose_remediation', {
+        action: 'kubectl restart api',
+        justification: 'x',
+      }),
+      ResponseBuilder.toolCall('request_human_approval', {
+        message: 'Restart?',
+        diagnosis: 'x',
+        proposedAction: 'kubectl restart api',
+      }),
+      ResponseBuilder.toolCall('execute_remediation', {
+        action: 'kubectl scale deploy/api --replicas=10',
+      }),
+      ResponseBuilder.toolCall('report_unresolved', { summary: 'guard tripped' }),
+      ResponseBuilder.done('done'),
+    ]);
+
+    assert.strictEqual(result.status, 'unresolved');
+    assert.strictEqual(
+      executedCmd,
+      null,
+      "execShellCommand should not have been called when action didn't match"
+    );
+  });
+});
+
+describe('buildTriageRegistry — MCP integration', () => {
+  it('registers tools fetched from both MCP sidecars', async () => {
+    const deps = makeDeps();
+    const session = { results: [] as unknown[] };
+    const { registry } = await buildTriageRegistry(ALERT, session, deps);
+    const anthropic = registry.toAnthropic();
+    const names = anthropic.map((t) => t.name);
+    for (const expected of [
+      'prometheus_query',
+      'kubectl_describe',
+      'propose_remediation',
+      'request_human_approval',
+      'execute_remediation',
+      'report_resolved',
+      'report_unresolved',
+    ]) {
+      assert.ok(names.includes(expected), `expected ${expected} in registry`);
+    }
+  });
+
+  it('forwards MCP tool dispatch back to the sidecar', async () => {
+    const calls: { url: string; name: string; args: any }[] = [];
+    const deps = makeDeps({
+      mcpCallTool: async (url, name, args) => {
+        calls.push({ url, name, args });
+        return `result for ${name}`;
+      },
+    });
+
+    await drive(deps, [
+      ResponseBuilder.toolCall('prometheus_query', { query: 'up{}' }),
+      ResponseBuilder.toolCall('report_unresolved', { summary: 'test' }),
+      ResponseBuilder.done('done'),
+    ]);
+
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0]?.name, 'prometheus_query');
+    assert.deepStrictEqual(calls[0]?.args, { query: 'up{}' });
+    assert.match(calls[0]?.url ?? '', /7071/);
+  });
+});

--- a/tool-registry-incident-triage/src/types.ts
+++ b/tool-registry-incident-triage/src/types.ts
@@ -1,0 +1,34 @@
+/** Shared types between workflow, activity, and client. */
+
+export interface AlertPayload {
+  status: string;
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+  startsAt: string;
+  endsAt?: string;
+  fingerprint?: string;
+}
+
+export interface ProposedRemediation {
+  /** kubectl/promtool/etc command, or human-readable action. */
+  action: string;
+  /** Why the agent thinks this would help. */
+  justification: string;
+}
+
+export interface TriageResult {
+  status: "resolved" | "unresolved";
+  summary: string;
+  remediations: ProposedRemediation[];
+}
+
+export interface ApprovalRequest {
+  message: string;
+  diagnosis: string;
+  proposedAction: string;
+}
+
+export interface ApprovalResponse {
+  decision: "approved" | "rejected";
+  reason: string;
+}

--- a/tool-registry-incident-triage/src/worker.ts
+++ b/tool-registry-incident-triage/src/worker.ts
@@ -1,0 +1,47 @@
+/**
+ * Temporal worker for the TypeScript triage workflow.
+ *
+ * Connects to Temporal Cloud, polls the task queue picked from TEMPORAL_TASK_QUEUE
+ * (typically `triage-typescript`), registers both incidentTriageWorkflow and the
+ * approvalWorkflow companion (re-exported from workflows/triage.ts), and the
+ * triage activity.
+ */
+import { NativeConnection, Worker } from "@temporalio/worker";
+import { fileURLToPath } from "node:url";
+import * as triageActivities from "./activities/triage";
+
+async function run(): Promise<void> {
+  const address = process.env.TEMPORAL_ADDRESS;
+  const namespace = process.env.TEMPORAL_NAMESPACE;
+  const apiKey = process.env.TEMPORAL_API_KEY;
+  const taskQueue = process.env.TEMPORAL_TASK_QUEUE ?? "triage-typescript";
+
+  if (!address || !namespace || !apiKey) {
+    console.error("Missing TEMPORAL_ADDRESS / TEMPORAL_NAMESPACE / TEMPORAL_API_KEY");
+    process.exit(1);
+  }
+
+  console.log(`connecting to ${address} (ns=${namespace}) on task queue ${taskQueue}`);
+
+  const connection = await NativeConnection.connect({
+    address,
+    tls: {},
+    metadata: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  const worker = await Worker.create({
+    connection,
+    namespace,
+    taskQueue,
+    workflowsPath: fileURLToPath(new URL("./workflows/triage.ts", import.meta.url)),
+    activities: triageActivities,
+  });
+
+  console.log(`worker ready — polling ${taskQueue}`);
+  await worker.run();
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tool-registry-incident-triage/src/workflows/approval.ts
+++ b/tool-registry-incident-triage/src/workflows/approval.ts
@@ -1,0 +1,34 @@
+/**
+ * approvalWorkflow — companion HITL workflow.
+ *
+ * The triage agent's `request_human_approval` tool calls signalWithStart against
+ * a deterministic ID per alert group. This workflow stores the latest agent
+ * request, exposes it as a query, and returns the operator's decision.
+ *
+ * Why a separate workflow:
+ *  - LLM non-determinism is OK: a re-issued tool call re-attaches to the SAME
+ *    approval workflow instead of re-pinging the operator with a fresh request.
+ *  - Survives the worker pod dying mid-wait. The operator can take hours to
+ *    respond; the triage activity blocks on .result() of THIS workflow.
+ *  - Cleanly visible in the Temporal Cloud UI as a separate workflow type so
+ *    operators can list pending approvals without reading triage history.
+ */
+import { defineSignal, defineQuery, setHandler, condition } from "@temporalio/workflow";
+import type { ApprovalRequest, ApprovalResponse } from "../types";
+
+export const approvalRequestSignal = defineSignal<[ApprovalRequest]>("approval-request");
+export const approvalDecisionSignal = defineSignal<[ApprovalResponse]>("approval-decision");
+export const pendingApprovalQuery = defineQuery<ApprovalRequest | null>("pending-approval");
+
+export async function approvalWorkflow(_workflowKey: string): Promise<ApprovalResponse> {
+  let request: ApprovalRequest | null = null;
+  let response: ApprovalResponse | null = null;
+
+  setHandler(pendingApprovalQuery, () => request);
+  setHandler(approvalRequestSignal, (req) => { request = req; });
+  setHandler(approvalDecisionSignal, (res) => { response = res; });
+
+  await condition(() => request !== null);
+  await condition(() => response !== null);
+  return response!;
+}

--- a/tool-registry-incident-triage/src/workflows/triage.ts
+++ b/tool-registry-incident-triage/src/workflows/triage.ts
@@ -1,0 +1,43 @@
+/**
+ * incidentTriageWorkflow — single-activity workflow that delegates to the
+ * agent. Workflow ID is set deterministically by the webhook receiver
+ * (`triage-${alertname}-${service}`), so re-fires from AlertManager re-attach
+ * to the running workflow rather than spawning a new one.
+ *
+ * The `alert-update` signal lets the webhook hand fresh alert state to the
+ * running activity if AlertManager re-fires (e.g., updated annotations) — the
+ * agent can read the latest state via a query.
+ */
+import {
+  proxyActivities,
+  setHandler,
+  defineSignal,
+  defineQuery,
+} from "@temporalio/workflow";
+
+import type * as TriageActivities from "../activities/triage";
+import type { AlertPayload, TriageResult } from "../types";
+
+export { approvalWorkflow } from "./approval"; // re-export so the worker bundle picks it up
+
+export const alertUpdateSignal = defineSignal<[AlertPayload]>("alert-update");
+export const currentAlertQuery = defineQuery<AlertPayload | null>("current-alert");
+export const triageResultQuery = defineQuery<TriageResult | null>("triage-result");
+
+const { triageIncidentActivity } = proxyActivities<typeof TriageActivities>({
+  startToCloseTimeout: "8h",     // matches lexicon-temporal's `agenticHitl` profile
+  heartbeatTimeout: "120s",
+  retry: { maximumAttempts: 1 }, // AgenticSession heartbeat is the resume mechanism
+});
+
+export async function incidentTriageWorkflow(initialAlert: AlertPayload): Promise<TriageResult> {
+  let currentAlert: AlertPayload = initialAlert;
+  let result: TriageResult | null = null;
+
+  setHandler(currentAlertQuery, () => currentAlert);
+  setHandler(triageResultQuery, () => result);
+  setHandler(alertUpdateSignal, (alert) => { currentAlert = alert; });
+
+  result = await triageIncidentActivity(currentAlert);
+  return result;
+}

--- a/tool-registry-incident-triage/tsconfig.json
+++ b/tool-registry-incident-triage/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "version": "5.6.3",
+  "compilerOptions": {
+    "lib": ["es2021"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "./src",
+    "outDir": "./lib"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Adds a new sample under `tool-registry-incident-triage/` demonstrating `@temporalio/tool-registry` end-to-end.

The example includes:

- Long-running activity wrapped in `agenticSession` with heartbeat checkpointing.
- MCP HTTP integration via the sidecar pattern (Prometheus + Kubernetes MCP servers).
- Human-in-the-loop tool calls via a companion workflow (deterministic ID, two signals, one query).
- A testable activity refactor: `buildTriageRegistry(alert, session, deps)` returning `{ registry, getResult }` plus a `TriageDeps` interface of I/O callables, so unit tests substitute fakes and drive the registry via `MockProvider`.

Mocha tests in `src/mocha/triage_activity.test.ts` use `MockProvider` and require no API key or running Temporal server. All 6 tests pass.

Conventions followed:
- `src/` layout with `src/mocha/*.test.ts` (per `hello-world` template).
- Standard `package.json` scripts (`build`, `start`, `workflow`, `test`, `lint`, `format`).
- Added entry to `.scripts/list-of-samples.json` (alphabetical).
- Added entry to root `README.md` under "Activity APIs and design patterns".

**Known transitional issue:** the dependency on `@temporalio/tool-registry` currently uses a `file:` path (`file:../../sdk-typescript/packages/tool-registry`) since the package isn't published yet. The sibling sdk-typescript PR (#2008) recently added a `prepare` script which causes `npm install` to attempt a workspace-wide build that fails on unrelated worker-package issues. Workaround: `npm install --ignore-scripts`. Will switch to a published version pin once temporalio/sdk-typescript#2008 lands and the package publishes.

Cross-references the SDK PR (temporalio/sdk-typescript#2008) which adds the `@temporalio/tool-registry` package itself.