### PR TITLE
VLN-1386: remediate missing-dependency-cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 14

--- a/.npmrc
+++ b/.npmrc
@@ -12,3 +12,6 @@ public-hoist-pattern = []
 # structure. To work around this, hoist all postcss-* packages.
 # FIXME: Can't we do something equivalent at the project-level instead?
 public-hoist-pattern[] = postcss-*
+
+# Require package versions to be at least 14 days old before install.
+minimum-release-age = 20160


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>missing-dependency-cooldown</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/samples-typescript</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1386">VLN-1386</a></td></tr>
</table>

## Summary

- `.npmrc`: Added pnpm native dependency cooldown by setting `minimum-release-age = 20160` (14 days in minutes), preserving all existing settings.
- `.github/dependabot.yml`: Added Dependabot configuration with weekly updates for `npm` and `github-actions`, each including `cooldown.default-days: 14`.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix