### PR TITLE
Pin next to ^16.2.6 to avoid broken 16.3.0-preview.0 release

### DIFF
--- a/nextjs-ecommerce-oneclick/package.json
+++ b/nextjs-ecommerce-oneclick/package.json
@@ -24,7 +24,7 @@
     "@temporalio/envconfig": "^1.20.3",
     "@temporalio/worker": "^1.20.3",
     "@temporalio/workflow": "^1.20.3",
-    "next": "latest",
+    "next": "^16.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-toastify": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2539,7 +2539,7 @@ importers:
         specifier: ^1.20.3
         version: 1.20.3
       next:
-        specifier: latest
+        specifier: ^16.2.6
         version: 16.2.9(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0


### PR DESCRIPTION
## What was changed

Pin `next` to `^16.2.6` in `nextjs-ecommerce-oneclick` (was `latest`) and update the lockfile.

## Why

npm's `latest` dist-tag for `next` currently points to `16.3.0-preview.0`, whose `@next/swc-linux-x64-gnu` binary was never published. Any CI job that resolves `next@latest` fresh (or any regenerated lockfile) picks up the broken preview and `next build` fails with a 404 downloading the SWC binary:

```
⨯ Failed to download swc package from https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0-preview.0.tgz
unhandledRejection Error: request failed with status 404
```

Pinning to `^16.2.6` keeps the existing stable resolution and excludes prereleases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)