### PR TITLE
Address mutex test hangs

### DIFF
--- a/mutex/src/activities.ts
+++ b/mutex/src/activities.ts
@@ -4,13 +4,13 @@ import { LockRequest, lockRequestSignal } from './shared';
 
 export function createActivities(client: Client) {
   return {
-    async signalWithStartLockWorkflow(resourceId: string, timeoutMs: number) {
+    async signalWithStartLockWorkflow(resourceId: string, timeoutMs: number, taskQueue: string) {
       const req: LockRequest = {
         initiatorId: activityInfo().workflowExecution!.workflowId,
         timeoutMs,
       };
       await client.workflow.signalWithStart('lockWorkflow', {
-        taskQueue: activityInfo().taskQueue,
+        taskQueue,
         workflowId: resourceId,
         signal: lockRequestSignal,
         signalArgs: [req],

--- a/mutex/src/workflows.ts
+++ b/mutex/src/workflows.ts
@@ -69,7 +69,7 @@ export async function oneAtATimeWorkflow(resourceId: string, sleepForMs = 500, l
   const hasLock = () => !!releaseSignalName;
 
   // Send a signal to the given lock Workflow to acquire the lock
-  await signalWithStartLockWorkflow(resourceId, lockTimeoutMs);
+  await signalWithStartLockWorkflow(resourceId, lockTimeoutMs, workflowInfo().taskQueue);
   await condition(hasLock);
 
   await notifyLocked(resourceId, releaseSignalName);


### PR DESCRIPTION
Explicitly pass task queue to the signalWithStartLockWorkflow call to ensure the lock workflow is added to the task queue being polled.