### PR TITLE
AI-304: Layout-agnostic shared eslintrc; fix outdated post-create messages

### DIFF
--- a/.scripts/copy-shared-files.mjs
+++ b/.scripts/copy-shared-files.mjs
@@ -42,7 +42,6 @@ const GITIGNORE_EXCLUDE = [
   'nestjs-exchange-rates',
 ];
 const ESLINTRC_EXCLUDE = [
-  'openai-agents',
   'nextjs-ecommerce-oneclick',
   'monorepo-folders',
   'fetch-esm',
@@ -64,6 +63,14 @@ const ESLINTIGNORE_EXCLUDE = [
 
 const POST_CREATE_EXCLUDE = [
   'openai-agents',
+  'env-config',
+  'dsl-interpreter',
+  'eager-workflow-start',
+  'standalone-activity',
+  'state',
+  'nexus-cancellation',
+  'nexus-hello',
+  'nexus-messaging',
   'schedules',
   'timer-examples',
   'query-subscriptions',

--- a/.shared/.eslintrc.js
+++ b/.shared/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/activities-cancellation-heartbeating/.eslintrc.js
+++ b/activities-cancellation-heartbeating/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/activities-dependency-injection/.eslintrc.js
+++ b/activities-dependency-injection/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/activities-examples/.eslintrc.js
+++ b/activities-examples/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/ai-sdk/.eslintrc.js
+++ b/ai-sdk/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/batch-sliding-window/.eslintrc.js
+++ b/batch-sliding-window/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/child-workflows/.eslintrc.js
+++ b/child-workflows/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/continue-as-new/.eslintrc.js
+++ b/continue-as-new/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/cron-workflows/.eslintrc.js
+++ b/cron-workflows/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/custom-logger/.eslintrc.js
+++ b/custom-logger/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/dsl-interpreter/.eslintrc.js
+++ b/dsl-interpreter/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/dsl-interpreter/.post-create
+++ b/dsl-interpreter/.post-create
@@ -12,7 +12,11 @@ Use Node version 18+ (v22.x is recommended):
 Mac: {cyan brew install node@22}
 Other: https://nodejs.org/en/download/
 
-Then, in the project directory, using two other shells, run these commands:
+Then, in the project directory, start the Worker:
 
 {cyan npm run start.watch}
-{cyan npm run workflow}
+
+In another shell, run one of the sample Workflows:
+
+{cyan npm run workflow1}
+{cyan npm run workflow2}

--- a/eager-workflow-start/.eslintrc.js
+++ b/eager-workflow-start/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/eager-workflow-start/.post-create
+++ b/eager-workflow-start/.post-create
@@ -12,7 +12,6 @@ Use Node version 18+ (v22.x is recommended):
 Mac: {cyan brew install node@22}
 Other: https://nodejs.org/en/download/
 
-Then, in the project directory, using two other shells, run these commands:
+Then, in the project directory, run the sample:
 
-{cyan npm run start.watch}
-{cyan npm run workflow}
+{cyan npm run start}

--- a/early-return/.eslintrc.js
+++ b/early-return/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/ejson/.eslintrc.js
+++ b/ejson/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/empty/.eslintrc.js
+++ b/empty/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/encryption/.eslintrc.js
+++ b/encryption/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/env-config/.eslintrc.js
+++ b/env-config/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/env-config/.post-create
+++ b/env-config/.post-create
@@ -12,7 +12,7 @@ Use Node version 18+ (v22.x is recommended):
 Mac: {cyan brew install node@22}
 Other: https://nodejs.org/en/download/
 
-Then, in the project directory, using two other shells, run these commands:
+This sample loads Temporal Client configuration from a TOML file. In the project directory, run either:
 
-{cyan npm run start.watch}
-{cyan npm run workflow}
+{cyan npm run load-default}
+{cyan npm run load-profile}

--- a/expense/.eslintrc.js
+++ b/expense/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/grpc-calls/.eslintrc.js
+++ b/grpc-calls/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/hello-world-mtls/.eslintrc.js
+++ b/hello-world-mtls/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/hello-world/.eslintrc.js
+++ b/hello-world/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/interceptors-opentelemetry/.eslintrc.js
+++ b/interceptors-opentelemetry/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/lambda-worker/.eslintrc.js
+++ b/lambda-worker/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/message-passing/execute-update/.eslintrc.js
+++ b/message-passing/execute-update/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/message-passing/introduction/.eslintrc.js
+++ b/message-passing/introduction/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/message-passing/safe-message-handlers/.eslintrc.js
+++ b/message-passing/safe-message-handlers/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/mutex/.eslintrc.js
+++ b/mutex/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/nexus-cancellation/.eslintrc.js
+++ b/nexus-cancellation/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/nexus-cancellation/.post-create
+++ b/nexus-cancellation/.post-create
@@ -12,7 +12,10 @@ Use Node version 18+ (v22.x is recommended):
 Mac: {cyan brew install node@22}
 Other: https://nodejs.org/en/download/
 
-Then, in the project directory, using two other shells, run these commands:
+This sample uses Nexus, so first create the namespaces and Nexus endpoint as described in the README.
 
-{cyan npm run start.watch}
+Then, in the project directory, start the service Worker, the caller Worker, and the Workflow in three separate shells:
+
+{cyan npm run start.service}
+{cyan npm run start.caller}
 {cyan npm run workflow}

--- a/nexus-hello/.eslintrc.js
+++ b/nexus-hello/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/nexus-hello/.post-create
+++ b/nexus-hello/.post-create
@@ -12,7 +12,10 @@ Use Node version 18+ (v22.x is recommended):
 Mac: {cyan brew install node@22}
 Other: https://nodejs.org/en/download/
 
-Then, in the project directory, using two other shells, run these commands:
+This sample uses Nexus, so first create the namespaces and Nexus endpoint as described in the README.
 
-{cyan npm run start.watch}
+Then, in the project directory, start the service Worker, the caller Worker, and the Workflow in three separate shells:
+
+{cyan npm run start.service}
+{cyan npm run start.caller}
 {cyan npm run workflow}

--- a/nexus-messaging/.eslintrc.js
+++ b/nexus-messaging/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/nexus-messaging/.post-create
+++ b/nexus-messaging/.post-create
@@ -12,7 +12,12 @@ Use Node version 18+ (v22.x is recommended):
 Mac: {cyan brew install node@22}
 Other: https://nodejs.org/en/download/
 
-Then, in the project directory, using two other shells, run these commands:
+This sample uses Nexus and has two self-contained patterns (callerpattern and ondemandpattern). First create the namespaces and Nexus endpoint as described in the README.
 
-{cyan npm run start.watch}
-{cyan npm run workflow}
+For the caller pattern, start the service Worker, the caller Worker, and the Workflow in three separate shells:
+
+{cyan npm run start.callerpattern.service}
+{cyan npm run start.callerpattern.caller}
+{cyan npm run workflow.callerpattern}
+
+The on-demand pattern has an equivalent ondemandpattern trio of scripts -- see the README.

--- a/openai-agents/.eslintrc.js
+++ b/openai-agents/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/*/workflows.ts', 'src/*/workflows-*.ts', 'src/*/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/patching-api/.eslintrc.js
+++ b/patching-api/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/polling/infrequent/.eslintrc.js
+++ b/polling/infrequent/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/production/.eslintrc.js
+++ b/production/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/query-subscriptions/.eslintrc.js
+++ b/query-subscriptions/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/saga/.eslintrc.js
+++ b/saga/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/schedules/.eslintrc.js
+++ b/schedules/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/scratchpad/.eslintrc.js
+++ b/scratchpad/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/search-attributes/.eslintrc.js
+++ b/search-attributes/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/signals-queries/.eslintrc.js
+++ b/signals-queries/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/sinks/.eslintrc.js
+++ b/sinks/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/sleep-for-days/.eslintrc.js
+++ b/sleep-for-days/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/snippets/.eslintrc.js
+++ b/snippets/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/standalone-activity/.eslintrc.js
+++ b/standalone-activity/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/standalone-activity/.post-create
+++ b/standalone-activity/.post-create
@@ -12,7 +12,11 @@ Use Node version 18+ (v22.x is recommended):
 Mac: {cyan brew install node@22}
 Other: https://nodejs.org/en/download/
 
-Then, in the project directory, using two other shells, run these commands:
+Then, in the project directory, start the Worker:
 
 {cyan npm run start.watch}
-{cyan npm run workflow}
+
+In another shell, execute the Activity, then list executions:
+
+{cyan npm run execute}
+{cyan npm run list}

--- a/state/.eslintrc.js
+++ b/state/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/state/.post-create
+++ b/state/.post-create
@@ -12,7 +12,13 @@ Use Node version 18+ (v22.x is recommended):
 Mac: {cyan brew install node@22}
 Other: https://nodejs.org/en/download/
 
-Then, in the project directory, using two other shells, run these commands:
+Then, in the project directory, start the Worker:
 
 {cyan npm run start.watch}
-{cyan npm run workflow}
+
+In another shell, start the Workflow and interact with it via Query, Signal, and cancellation:
+
+{cyan npm run workflow.start}
+{cyan npm run workflow.query}
+{cyan npm run workflow.signal}
+{cyan npm run workflow.cancel}

--- a/timer-examples/.eslintrc.js
+++ b/timer-examples/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/timer-progress/.eslintrc.js
+++ b/timer-progress/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/vscode-debugger/.eslintrc.js
+++ b/vscode-debugger/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/worker-specific-task-queues/.eslintrc.js
+++ b/worker-specific-task-queues/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/worker-versioning/.eslintrc.js
+++ b/worker-versioning/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/workflow-streams/.eslintrc.js
+++ b/workflow-streams/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/workflows.ts', 'src/workflows-*.ts', 'src/workflows/*.ts'],
+      files: ['src/**/workflows.ts', 'src/**/workflows-*.ts', 'src/**/workflows/*.ts'],
       rules: {
         'no-restricted-imports': [
           'error',


### PR DESCRIPTION
Broaden the shared eslintrc workflow-override glob to `src/**/workflows*.ts` so the no-node-builtins rule covers nested per-scenario layouts (e.g. openai-agents' `src/<feature>/workflows.ts`), letting openai-agents use the shared eslintrc and drop out of `ESLINTRC_EXCLUDE`. All samples' eslintrc copies are re-synced.

Also fixes 8 samples (env-config, dsl-interpreter, eager-workflow-start, standalone-activity, state, nexus-cancellation, nexus-hello, nexus-messaging) whose `.post-create` told users to run npm scripts that don't exist (`start.watch`/`workflow`); each now matches its real scripts and is excluded from the shared post-create.