### PR TITLE
Fix stale package location in workflow-streams README

### DIFF
--- a/workflow-streams/README.md
+++ b/workflow-streams/README.md
@@ -1,8 +1,8 @@
 # Workflow Streams
 
 > **Experimental.** These samples use `@temporalio/workflow-streams`, which is
-> currently distributed on the `contrib/pubsub` branch of `sdk-typescript`. The
-> module is experimental and its API may change.
+> published on npm and lives under `contrib/workflow-streams` in
+> `sdk-typescript`. The module is experimental and its API may change.
 
 `@temporalio/workflow-streams` lets a workflow host a durable,
 offset-addressed event channel. The workflow holds an append-only log;


### PR DESCRIPTION
The workflow-streams README said `@temporalio/workflow-streams` is distributed on the `contrib/pubsub` branch of `sdk-typescript`, but that branch no longer exists. The package is now published on npm and lives under `contrib/workflow-streams`.