### PR TITLE
Add CODEOWNERS entries for the AI integration sample directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,7 @@
 # someone opens a pull request.
 * @temporalio/sdk
 /ai-sdk/           @temporalio/sdk @temporalio/ai-sdk
+/langsmith/        @temporalio/sdk @temporalio/ai-sdk
+/openai-agents/    @temporalio/sdk @temporalio/ai-sdk
+/strands-agents/   @temporalio/sdk @temporalio/ai-sdk
 /workflow-streams/ @temporalio/sdk @temporalio/ai-sdk


### PR DESCRIPTION
Assigns the openai-agents, langsmith, and strands-agents sample directories to @temporalio/sdk and @temporalio/ai-sdk, matching the existing ai-sdk and workflow-streams entries.