### PR TITLE
Fix duplicate snipsync IDs shared with hello-world

### DIFF
--- a/empty/src/client.ts
+++ b/empty/src/client.ts
@@ -1,4 +1,4 @@
-// @@@SNIPSTART typescript-hello-client
+// @@@SNIPSTART typescript-empty-client
 import { Connection, Client } from '@temporalio/client';
 import { loadClientConnectConfig } from '@temporalio/envconfig';
 import { nanoid } from 'nanoid';

--- a/empty/src/worker.ts
+++ b/empty/src/worker.ts
@@ -1,4 +1,4 @@
-// @@@SNIPSTART typescript-hello-worker
+// @@@SNIPSTART typescript-empty-worker
 import { NativeConnection, Worker } from '@temporalio/worker';
 import * as activities from './activities';
 import { TASK_QUEUE_NAME } from './shared';

--- a/sleep-for-days/src/client.ts
+++ b/sleep-for-days/src/client.ts
@@ -1,4 +1,4 @@
-// @@@SNIPSTART typescript-hello-client
+// @@@SNIPSTART typescript-sleep-for-days-client
 import { Connection, Client } from '@temporalio/client';
 import { loadClientConnectConfig } from '@temporalio/envconfig';
 import { sleepForDays } from './workflows';

--- a/sleep-for-days/src/worker.ts
+++ b/sleep-for-days/src/worker.ts
@@ -1,4 +1,4 @@
-// @@@SNIPSTART typescript-hello-worker
+// @@@SNIPSTART typescript-sleep-for-days-worker
 import { NativeConnection, Worker } from '@temporalio/worker';
 import * as activities from './activities';
 


### PR DESCRIPTION
## What

Renames four snipsync markers so `typescript-hello-worker` and `typescript-hello-client` are unique to `hello-world/`.

| File | Was | Now |
|---|---|---|
| `empty/src/worker.ts` | `typescript-hello-worker` | `typescript-empty-worker` |
| `empty/src/client.ts` | `typescript-hello-client` | `typescript-empty-client` |
| `sleep-for-days/src/worker.ts` | `typescript-hello-worker` | `typescript-sleep-for-days-worker` |
| `sleep-for-days/src/client.ts` | `typescript-hello-client` | `typescript-sleep-for-days-client` |

Comment-only change; no code is touched.

## Why

`empty/` and `sleep-for-days/` look scaffolded from `hello-world/` and kept its snippet IDs, so each of those two IDs was defined in **three** files. Snipsync resolves duplicates silently rather than erroring, so whichever file it happens to read last wins.

This is not hypothetical. A docs page referencing `typescript-hello-worker` for a "Create and run a Worker" section pulled in `sleep-for-days/src/worker.ts` instead of `hello-world/src/worker.ts`, giving the reader a source link to an unrelated sample.

`typescript-hello-worker` is the only one of these currently referenced by the docs, so this change has no effect on any other page.

## Not fixed here

Three other duplicate IDs exist in this repo. Each is duplicated *within* a single sample directory, so the intended source is ambiguous and none is referenced by the docs today:

- `typescript-esm-client` — `fetch-esm/src/client-local.ts`, `fetch-esm/src/client-fetch.ts`
- `typescript-message-passing-introduction` — `message-passing/introduction/src/{client,worker}.ts`
- `typescript-polling-infrequent` — `polling/infrequent/src/{workflows,client,worker}.ts`

Happy to fold those in if you'd prefer one sweep.