### PR TITLE
docs(standalone-activity): add snipsync markers for the docs page

### DIFF
--- a/standalone-activity/src/activities.ts
+++ b/standalone-activity/src/activities.ts
@@ -1,3 +1,4 @@
+// @@@SNIPSTART typescript-standalone-activity-definition
 import { ApplicationFailure } from '@temporalio/activity';
 
 export async function greet(name: string): Promise<string> {
@@ -6,3 +7,4 @@ export async function greet(name: string): Promise<string> {
   }
   return `Hello, ${name}!`;
 }
+// @@@SNIPEND

--- a/standalone-activity/src/execute.ts
+++ b/standalone-activity/src/execute.ts
@@ -21,14 +21,18 @@ async function run() {
   const activityId = nanoid();
 
   // Handle can be used to get information and control the activity
+  // @@@SNIPSTART typescript-standalone-activity-start
   const handle = await activitiesClient.start('greet', {
     ...activityOptions,
     id: activityId,
     args: ['Temporal'],
   });
+  // @@@SNIPEND
 
   // Optional: wait for activity result
+  // @@@SNIPSTART typescript-standalone-activity-result
   console.log(await handle.result()); // Hello, Temporal!
+  // @@@SNIPEND
 
   // `execute` allows starting the activity and getting the result in one go
   const result = await activitiesClient.execute('greet', {
@@ -39,7 +43,9 @@ async function run() {
   console.log(result); // Hello, World!
 
   // If needed, activity handle can be recreated from just activity ID, although with weaker type safety
+  // @@@SNIPSTART typescript-standalone-activity-get-handle
   const newHandle = client.activity.getHandle<string>(activityId);
+  // @@@SNIPEND
   console.log(await newHandle.result()); // Hello, Temporal!
 
   // Activity client can execute activities without the typed interface - useful when activity declarations are unavailable

--- a/standalone-activity/src/list.ts
+++ b/standalone-activity/src/list.ts
@@ -9,8 +9,10 @@ async function run() {
   // Documentation for query syntax available at https://docs.temporal.io/list-filter
   const query = 'TaskQueue="hello-standalone-activities"';
 
+  // @@@SNIPSTART typescript-standalone-activity-count
   const { count } = await client.activity.count(query);
   console.log(`Total activities: ${count}`);
+  // @@@SNIPEND
 
   console.log('ACTIVITY ID | RUN ID | ACTIVITY TYPE | STATUS | COMPLETED TIME');
 

--- a/standalone-activity/src/worker.ts
+++ b/standalone-activity/src/worker.ts
@@ -1,3 +1,4 @@
+// @@@SNIPSTART typescript-standalone-activity-worker
 import { NativeConnection, Worker } from '@temporalio/worker';
 import * as activities from './activities';
 import { loadClientConnectConfig } from '@temporalio/envconfig';
@@ -22,3 +23,4 @@ run().catch((err) => {
   console.error(err);
   process.exit(1);
 });
+// @@@SNIPEND


### PR DESCRIPTION
The [TypeScript Standalone Activities](https://docs.temporal.io/develop/typescript/activities/standalone-activities) docs page carries ten inline code blocks copied by hand from this sample, so nothing catches drift between the two. They have already diverged: the docs say "business identifier" where `execute.ts` says "business ID", and they strip the `async function run()` wrapper.

This adds markers around the six regions the docs reproduce verbatim:

| Marker | File |
|---|---|
| `typescript-standalone-activity-definition` | `activities.ts` (whole file) |
| `typescript-standalone-activity-worker` | `worker.ts` (whole file) |
| `typescript-standalone-activity-start` | `execute.ts` |
| `typescript-standalone-activity-result` | `execute.ts` |
| `typescript-standalone-activity-get-handle` | `execute.ts` |
| `typescript-standalone-activity-count` | `list.ts` |

Comment-only change, 12 lines. No behavior change.

## Why only six of ten

The other four docs blocks are deliberately left unmarked, because marking them would degrade the rendered page:

- **Client setup** and **the typed `execute` call** merge non-adjacent regions of `execute.ts`. `selectedLines` handles non-contiguous ranges, but snipsync inserts a literal `// ...` at each seam, and because the imports sit at column 0 the common-prefix dedent computes to empty, so the function body would render indented under flush-left imports.
- **The untyped `execute` block** needs `id: activityId`, but the sample must use a suffixed id to avoid an Activity Id collision inside its single run.
- **The list query + loop** spans two regions that `list.ts` separates with the count call.

Fixing those means reshaping the sample around the docs, which doesn't seem like the right trade.

## Verification

`npm run build`, `npm run lint`, and `prettier --check` all pass on `standalone-activity`. No new duplicate marker IDs.

On the docs side I reproduced snipsync's output for all six markers (driving its own `deindentByCommonPrefix`) and confirmed each matches the current page content byte-for-byte, so the first `yarn snipsync` after this merges is a no-op rather than a surprise rewrite.

Docs-side PR: https://github.com/temporalio/documentation/pull/5024
