### PR TITLE
fix(ai-sdk): spawn the MCP server without requiring a build

### DIFF
--- a/ai-sdk/src/mcp-server.ts
+++ b/ai-sdk/src/mcp-server.ts
@@ -46,7 +46,8 @@ server.registerTool(
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.log('Pokemon MCP Server running on stdio');
+  // Log to stderr: stdout is the JSON-RPC channel for a stdio MCP server.
+  console.error('Pokemon MCP Server running on stdio');
 }
 
 main().catch((error) => {

--- a/ai-sdk/src/worker.ts
+++ b/ai-sdk/src/worker.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { NativeConnection, Worker } from '@temporalio/worker';
 import * as activities from './activities';
 import { AiSdkPlugin } from '@temporalio/ai-sdk';
@@ -12,12 +13,23 @@ async function run() {
   try {
     // This is only used by the MCP Sample
     // @@@SNIPSTART typescript-vercel-ai-sdk-mcp-client-factories
+    // Resolve the MCP server script to an absolute path so it's found regardless of the Worker's
+    // cwd, and run it with the same runtime as the Worker: ts-node when running the sources in
+    // `src`, plain node when running the compiled output in `lib`.
+    const mcpServerPath = require.resolve('./mcp-server');
+    const mcpServerArgs = mcpServerPath.endsWith('.ts')
+      ? ['-r', require.resolve('ts-node/register'), mcpServerPath]
+      : [mcpServerPath];
+
     const mcpClientFactories = {
       testServer: () =>
         createMCPClient({
           transport: new StdioClientTransport({
-            command: 'node',
-            args: ['lib/mcp-server.js'],
+            // The same Node binary that's running this Worker.
+            command: process.execPath,
+            args: mcpServerArgs,
+            // Run from the project root so ts-node picks up this project's tsconfig.json.
+            cwd: path.resolve(__dirname, '..'),
           }),
         }),
     };

--- a/ai-sdk/src/worker.ts
+++ b/ai-sdk/src/worker.ts
@@ -13,9 +13,6 @@ async function run() {
   try {
     // This is only used by the MCP Sample
     // @@@SNIPSTART typescript-vercel-ai-sdk-mcp-client-factories
-    // Resolve the MCP server script to an absolute path so it's found regardless of the Worker's
-    // cwd, and run it with the same runtime as the Worker: ts-node when running the sources in
-    // `src`, plain node when running the compiled output in `lib`.
     const mcpServerPath = require.resolve('./mcp-server');
     const mcpServerArgs = mcpServerPath.endsWith('.ts')
       ? ['-r', require.resolve('ts-node/register'), mcpServerPath]
@@ -25,10 +22,8 @@ async function run() {
       testServer: () =>
         createMCPClient({
           transport: new StdioClientTransport({
-            // The same Node binary that's running this Worker.
             command: process.execPath,
             args: mcpServerArgs,
-            // Run from the project root so ts-node picks up this project's tsconfig.json.
             cwd: path.resolve(__dirname, '..'),
           }),
         }),


### PR DESCRIPTION
## What

The `ai-sdk` sample's MCP client factory spawned the MCP server as `node lib/mcp-server.js` — a cwd-relative path into compiled output that neither `npm start` nor `npm run start.watch` produces, since both run the Worker straight from `src` via ts-node.

On a fresh clone, `npm run workflow mcp` failed on every attempt (retried forever) with:

```
MCPClientError: Connection closed
    at DefaultMCPClient.onClose (@ai-sdk/mcp/src/tool/mcp-client.ts:1263:19)
    at StdioClientTransport.DefaultMCPClient.transport.onclose (@ai-sdk/mcp/src/tool/mcp-client.ts:438:41)
    at ChildProcess.<anonymous> (@modelcontextprotocol/sdk/src/client/stdio.ts:152:31)
    at ChildProcess.emit (node:events:509:28)
    at maybeClose (node:internal/child_process:1124:16)
```

The child process exited immediately with `MODULE_NOT_FOUND`, the stdio transport fired `onclose`, and the pending `initialize` request was rejected. The message is generic enough that it reads like a broken MCP session rather than "the server script isn't there".

## Changes

- `ai-sdk/src/worker.ts` — resolve the server with `require.resolve('./mcp-server')`, so the path is absolute (cwd-independent) and follows whichever output is actually running: `src/mcp-server.ts` under ts-node, `lib/mcp-server.js` when compiled. Spawn it with `process.execPath` (the same Node binary running the Worker) plus `-r ts-node/register` for the TypeScript case, and set the child `cwd` to the project root so ts-node finds this project's `tsconfig.json`.
- `ai-sdk/src/mcp-server.ts` — move the startup banner from `console.log` to `console.error`. stdout is the JSON-RPC channel of a stdio MCP server, so that line was being fed to the client's read buffer as a bogus message (swallowed as a parse error, but latent breakage).

No build step is required anymore, which matches the README's setup instructions.

## Testing

`temporal server start-dev` + `npm start` + `npm run workflow mcp` against a fresh, unbuilt `lib/`:

```
Running mcp
Started workflow workflow-PdAVOTgNvQ1fHa0Bq9CQK
Lickitung is a Normal-type Pokémon known for its long tongue and playful nature. ...
  - **Own Tempo**: Prevents Lickitung from becoming confused.
  - **Oblivious**: Prevents Lickitung from being infatuated or taunted.
  - **Cloud Nine**: Negates the effects of weather during battle.
```

- `testServer-listTools` and `testServer-callTool` both succeeded on the first attempt — no retries, no `Connection closed`.
- Confirmed the spawned child was `node -r .../ts-node/register .../ai-sdk/src/mcp-server.ts`, and the banner landed on the Worker's stderr.
- Verified the compiled path too: `require.resolve('./mcp-server')` from `lib/worker.js` resolves to `lib/mcp-server.js` and takes the plain-node branch.
- Verified the ts-node branch works when the Worker is started from an unrelated cwd.
- `npm run build` and `prettier --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
