### PR TITLE
Fix OpenAI Agents MCP snippet boundary

### DIFF
--- a/openai-agents/src/mcp/worker.ts
+++ b/openai-agents/src/mcp/worker.ts
@@ -61,7 +61,6 @@ async function run() {
           mcpServerProviders: [...statelessProviders, ...statefulProviders],
         }),
       ],
-      // @@@SNIPEND
       bundlerOptions: {
         webpackConfigHook: (config) => ({
           ...config,
@@ -72,6 +71,7 @@ async function run() {
         }),
       },
     });
+    // @@@SNIPEND
 
     await worker.run();
   } finally {


### PR DESCRIPTION
## What does this PR do?

Moves the `typescript-openai-agents-mcp-worker` Snipsync end marker past the complete `Worker.create()` call. The current marker leaves the generated documentation excerpt with an open object literal.

This unblocks the review fix for temporalio/documentation#5137.

## Verification

- `pnpm --filter temporal-openai-agents format:check`
- `pnpm --filter temporal-openai-agents build`