### PR TITLE
AI-282: Add Google ADK snipsync markers

### DIFF
--- a/google-adk-agents/src/agent-chat/worker.ts
+++ b/google-adk-agents/src/agent-chat/worker.ts
@@ -5,6 +5,7 @@ import { offlineModelProvider } from './offline-model';
 async function run() {
   const connection = await NativeConnection.connect({ address: 'localhost:7233' });
   try {
+    // @@@SNIPSTART typescript-google-adk-agent-chat-worker
     const worker = await Worker.create({
       connection,
       taskQueue: 'google-adk-agent-chat',
@@ -14,6 +15,7 @@ async function run() {
       ],
     });
     await worker.run();
+    // @@@SNIPEND
   } finally {
     await connection.close();
   }

--- a/google-adk-agents/src/agent-chat/workflows.ts
+++ b/google-adk-agents/src/agent-chat/workflows.ts
@@ -20,12 +20,14 @@ export async function agentChat(messages: Message[] = [], turns = 0, runs = 1, t
   let processing = 0;
   let nextUpdate = 0;
   let currentUpdate = 0;
+  // @@@SNIPSTART typescript-google-adk-agent-chat-workflow
   const agent = new LlmAgent({
     name: 'assistant',
     model: new TemporalModel('gemini-2.5-flash'),
     instruction: 'Continue the conversation using its prior context. Respond in one sentence.',
   });
   const runner = new InMemoryRunner({ agent, appName: 'agent-chat' });
+  // @@@SNIPEND
   const sessionId = `run-${runs}`;
   await runner.sessionService.createSession({ appName: runner.appName, userId: 'user', sessionId });
   setHandler(getChatState, () => ({ messages, turns, runs }));


### PR DESCRIPTION
This adds two targeted Snipsync boundaries to the Google ADK agent-chat sample. The public integration guide uses them for the core TemporalModel and GoogleAdkPlugin setup; sample behavior is unchanged.

Verified with formatting, ESLint, TypeScript build, the 15 API-key-free Google ADK integration tests, and cross-repository snippet validation.