### PR TITLE
Add Nexus to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,15 @@
 # @temporalio/sdk will be requested for review when
 # someone opens a pull request.
 * @temporalio/sdk
+
+# SDK & Nexus teams share ownership of these files
+/.scripts/list-of-samples.json @temporalio/sdk @temporalio/nexus
+/README.md @temporalio/sdk @temporalio/nexus
+/pnpm-lock.yaml @temporalio/sdk @temporalio/nexus
+
+# The Nexus team owns any folder whose name starts with "nexus"
+/nexus*/ @temporalio/nexus
+
 /ai-sdk/            @temporalio/sdk @temporalio/ai-sdk
 /google-adk-agents/ @temporalio/sdk @temporalio/ai-sdk
 /langsmith/         @temporalio/sdk @temporalio/ai-sdk


### PR DESCRIPTION
## What was changed
Add the Nexus team as codeowners for samples and tests that start with "nexus". Also, add the Nexus team as co-owners of the `README` and `pnpm-lock.yaml`.