### PR TITLE
Cap CI jobs at 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -89,6 +90,7 @@ jobs:
 
   lint-format-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
The CI workflow sets no `timeout-minutes`, so a hung job burns GitHub's 6-hour default before failing — this bit temporalio/samples-python twice (a 360-minute job on `main` and a 4.5-hour hang on a PR) before temporalio/samples-python#364 added a cap there. Recent jobs finish in ~1–15 minutes, so a 30-minute cap is generous headroom while turning a hang into a fast, visible failure instead of a stuck PR.